### PR TITLE
feat: add Codex WebSocket transport

### DIFF
--- a/src/http/routes/proxy.ts
+++ b/src/http/routes/proxy.ts
@@ -243,7 +243,7 @@ const proxyRequest = async (
         signal: context.req.raw.signal,
       });
       if (webSocketResponse) {
-        usageRecorder.recordFinal(200);
+        usageRecorder.recordFinal(webSocketResponse.status);
         return webSocketResponse;
       }
       break;

--- a/src/http/routes/proxy.ts
+++ b/src/http/routes/proxy.ts
@@ -9,6 +9,7 @@ import {
 import { getRoutableProviderAccount } from "../../domain/providers/provider-service";
 import { prepareClaudeProxyRequest } from "../../providers/proxies/claude-proxy";
 import { prepareCodexProxyRequest } from "../../providers/proxies/codex-proxy";
+import { tryProxyCodexWebSocket } from "../../providers/proxies/codex-websocket";
 import { prepareCopilotProxyRequest } from "../../providers/proxies/copilot-proxy";
 import type { UsageRequestSource } from "../../usage/request-outcome";
 import {
@@ -233,6 +234,18 @@ const proxyRequest = async (
       upstreamUrl = codexProxy.upstreamUrl;
       requestBody = codexProxy.bodyText;
       responseTransformer = codexProxy.transformResponse;
+
+      const webSocketResponse = await tryProxyCodexWebSocket({
+        headers,
+        bodyJson: codexProxy.bodyJson,
+        accountKey: `${apiKeyId}:${account.id}`,
+        onTokenUsage: usageRecorder.onTokenUsage,
+        signal: context.req.raw.signal,
+      });
+      if (webSocketResponse) {
+        usageRecorder.recordFinal(200);
+        return webSocketResponse;
+      }
       break;
     }
 

--- a/src/providers/constants.ts
+++ b/src/providers/constants.ts
@@ -3,6 +3,7 @@
 export const CODEX_ACCOUNT_ID_HEADER = "ChatGPT-Account-Id";
 export const CODEX_RESPONSE_ENDPOINT =
   "https://chatgpt.com/backend-api/codex/responses";
+export const CODEX_WEBSOCKET_BETA_HEADER = "responses_websockets=2026-02-06";
 // https://github.com/anomalyco/opencode/blob/d848c9b6a32f408e8b9bf6448b83af05629454d0/packages/opencode/src/plugin/codex.ts#L619
 export const CODEX_ORIGINATOR = "opencode";
 

--- a/src/providers/proxies/codex-proxy.ts
+++ b/src/providers/proxies/codex-proxy.ts
@@ -1,5 +1,9 @@
 import type { CodexAccountMetadata } from "../metadata";
-import { isObjectRecord, readBooleanField } from "../../utils/object";
+import {
+  type JsonObject,
+  isObjectRecord,
+  readBooleanField,
+} from "../../utils/object";
 import {
   readOpenAiResponsesUsageFromResponse,
   readOpenAiResponsesUsageFromSseEvent,
@@ -17,9 +21,11 @@ import {
 const trimString = (value: unknown): string =>
   typeof value === "string" ? value.trim() : "";
 
-const transformCodexBody = (bodyJson: unknown, bodyText: string): string => {
+export const transformCodexBodyJson = (
+  bodyJson: unknown
+): JsonObject | null => {
   if (!isObjectRecord(bodyJson)) {
-    return bodyText;
+    return null;
   }
 
   // Codex's chatgpt.com backend endpoint behaves differently from generic OpenAI Responses:
@@ -42,10 +48,10 @@ const transformCodexBody = (bodyJson: unknown, bodyText: string): string => {
   const instructions =
     trimString(nextBody.instructions) || CODEX_DEFAULT_INSTRUCTIONS;
 
-  return JSON.stringify({
+  return {
     ...nextBody,
     instructions,
-  });
+  };
 };
 
 const transformCodexResponse = (
@@ -74,6 +80,7 @@ type CodexProxyPreparationInput = {
 type CodexProxyPreparationResult = {
   upstreamUrl: string;
   bodyText: string;
+  bodyJson: JsonObject | null;
   transformResponse(response: Response): Promise<Response>;
 };
 
@@ -82,6 +89,7 @@ export const prepareCodexProxyRequest = (
 ): CodexProxyPreparationResult => {
   const isStreamingRequest =
     readBooleanField(input.bodyJson, "stream") === true;
+  const bodyJson = transformCodexBodyJson(input.bodyJson);
 
   input.headers.set("authorization", `Bearer ${input.accessToken}`);
   if (!input.headers.get("originator")) {
@@ -95,7 +103,8 @@ export const prepareCodexProxyRequest = (
 
   return {
     upstreamUrl: CODEX_RESPONSE_ENDPOINT,
-    bodyText: transformCodexBody(input.bodyJson, input.bodyText),
+    bodyJson,
+    bodyText: bodyJson ? JSON.stringify(bodyJson) : input.bodyText,
     transformResponse: (response: Response): Promise<Response> =>
       transformCodexResponse(response, input.onTokenUsage, isStreamingRequest),
   };

--- a/src/providers/proxies/codex-websocket.ts
+++ b/src/providers/proxies/codex-websocket.ts
@@ -7,6 +7,7 @@ import type { TokenUsage } from "../../usage/token-usage";
 import { isObjectRecord, readBooleanField } from "../../utils/object";
 
 const SESSION_SOCKET_TTL_MS = 5 * 60 * 1000;
+const CONNECT_TIMEOUT_MS = 15_000;
 
 type WebSocketEventType = "open" | "message" | "error" | "close";
 type WebSocketListener = (event: unknown) => void;
@@ -126,12 +127,20 @@ const connectWebSocket = (
   if (!WebSocketCtor) {
     return Promise.reject(new Error("WebSocket is not available"));
   }
+  if (signal?.aborted) {
+    return Promise.reject(new Error("Request was aborted"));
+  }
 
   return new Promise((resolve, reject) => {
     let socket: WebSocketLike;
     let settled = false;
+    let timeout: ReturnType<typeof setTimeout> | null = null;
 
     const cleanup = (): void => {
+      if (timeout) {
+        clearTimeout(timeout);
+        timeout = null;
+      }
       socket.removeEventListener("open", onOpen);
       socket.removeEventListener("error", onError);
       socket.removeEventListener("close", onClose);
@@ -159,6 +168,10 @@ const connectWebSocket = (
       closeSocket(socket);
       fail(new Error("Request was aborted"));
     };
+    const onTimeout = (): void => {
+      closeSocket(socket);
+      fail(new Error("WebSocket connect timed out"));
+    };
 
     try {
       socket = new WebSocketCtor(resolveCodexWebSocketUrl(), {
@@ -173,6 +186,7 @@ const connectWebSocket = (
     socket.addEventListener("error", onError);
     socket.addEventListener("close", onClose);
     signal?.addEventListener("abort", onAbort);
+    timeout = setTimeout(onTimeout, CONNECT_TIMEOUT_MS);
   });
 };
 
@@ -196,12 +210,16 @@ const acquireSocket = async (
 
   const existing = socketCache.get(cacheKey);
   if (existing) {
+    if (existing.busy) {
+      throw new Error("Codex WebSocket session is busy");
+    }
+
     if (existing.idleTimer) {
       clearTimeout(existing.idleTimer);
       existing.idleTimer = null;
     }
 
-    if (!existing.busy && isSocketOpen(existing.socket)) {
+    if (isSocketOpen(existing.socket)) {
       existing.busy = true;
       return {
         socket: existing.socket,
@@ -218,17 +236,8 @@ const acquireSocket = async (
       };
     }
 
-    if (!existing.busy) {
-      closeSocket(existing.socket);
-      socketCache.delete(cacheKey);
-    }
-
-    const socket = await connectWebSocket(headers, signal);
-    return {
-      socket,
-      cached: null,
-      release: () => closeSocket(socket),
-    };
+    closeSocket(existing.socket);
+    socketCache.delete(cacheKey);
   }
 
   const socket = await connectWebSocket(headers, signal);
@@ -268,12 +277,10 @@ const withoutContinuationFields = (
   body: Record<string, unknown>
 ): Record<string, unknown> => {
   const {
-    background: _background,
     input: _input,
     previous_response_id: _previous,
-    stream: _stream,
     ...rest
-  } = body;
+  } = withoutTransportFields(body);
   return rest;
 };
 
@@ -287,15 +294,29 @@ const withoutTransportFields = (
 const sameJson = (left: unknown, right: unknown): boolean =>
   JSON.stringify(left) === JSON.stringify(right);
 
+const hasOwn = (body: Record<string, unknown>, key: string): boolean =>
+  Object.hasOwn(body, key);
+
+const toHex = (bytes: Uint8Array): string =>
+  Array.from(bytes, (byte) => byte.toString(16).padStart(2, "0")).join("");
+
+const deriveSessionId = async (
+  accountKey: string,
+  sessionId: string
+): Promise<string> => {
+  const data = new TextEncoder().encode(`${accountKey}:${sessionId}`);
+  const digest = await crypto.subtle.digest("SHA-256", data);
+  return `kleis_${toHex(new Uint8Array(digest)).slice(0, 48)}`;
+};
+
 const buildRequestBody = (
-  body: Record<string, unknown>,
+  webSocketBody: Record<string, unknown>,
   cached: CachedSocket | null
 ): Record<string, unknown> => {
-  const webSocketBody = withoutTransportFields(body);
   if (
     !cached?.continuation ||
     !Array.isArray(webSocketBody.input) ||
-    webSocketBody.previous_response_id
+    hasOwn(webSocketBody, "previous_response_id")
   ) {
     return webSocketBody;
   }
@@ -336,14 +357,21 @@ const decodeMessageData = (data: unknown): string | null => {
   if (typeof data === "string") {
     return data;
   }
-  if (data instanceof ArrayBuffer) {
-    return new TextDecoder().decode(data);
-  }
-  if (ArrayBuffer.isView(data)) {
+  if (data instanceof ArrayBuffer || ArrayBuffer.isView(data)) {
     return new TextDecoder().decode(data);
   }
   return null;
 };
+
+const readPayloadStatus = (payload: Record<string, unknown>): number => {
+  const status = payload.status;
+  return typeof status === "number" && status >= 400 && status <= 599
+    ? status
+    : 502;
+};
+
+const isErrorPayload = (payload: Record<string, unknown>): boolean =>
+  payload.type === "error" || payload.type === "response.failed";
 
 const buildWebSocketHeaders = (
   headers: Headers,
@@ -363,21 +391,29 @@ export const tryProxyCodexWebSocket = async (
   input: CodexWebSocketInput
 ): Promise<Response | null> => {
   const body = input.bodyJson;
-  if (!body || readBooleanField(body, "stream") !== true) {
+  if (
+    !body ||
+    readBooleanField(body, "stream") !== true ||
+    readBooleanField(body, "background") === true
+  ) {
     return null;
   }
 
   const sessionId = readSessionId(body, input.headers);
-  const requestId = sessionId ?? crypto.randomUUID();
+  const requestId = sessionId
+    ? await deriveSessionId(input.accountKey, sessionId)
+    : crypto.randomUUID();
   const cacheKey = sessionId ? `${input.accountKey}:${sessionId}` : null;
   const headers = buildWebSocketHeaders(input.headers, requestId);
 
   let acquired: Awaited<ReturnType<typeof acquireSocket>> | null = null;
-  const fullBody = withoutTransportFields(body);
+  const fullBody = withoutTransportFields(
+    sessionId ? { ...body, prompt_cache_key: requestId } : body
+  );
   let requestBody: Record<string, unknown>;
   try {
     acquired = await acquireSocket(headers, cacheKey, input.signal);
-    requestBody = buildRequestBody(body, acquired.cached);
+    requestBody = buildRequestBody(fullBody, acquired.cached);
   } catch {
     acquired?.release(false);
     return null;
@@ -388,112 +424,197 @@ export const tryProxyCodexWebSocket = async (
   const responseItems: unknown[] = [];
   let responseId: string | null = null;
   let keepSocket = true;
-
   let settled = false;
-  let cleanupStream: (() => void) | null = null;
+  let terminal = false;
+  let failure: unknown = null;
+  let wake: (() => void) | null = null;
+  const queue: Record<string, unknown>[] = [];
+
+  const wakePull = (): void => {
+    if (!wake) {
+      return;
+    }
+    const resolve = wake;
+    wake = null;
+    resolve();
+  };
+
+  let firstPayloadResolve: ((payload: Record<string, unknown>) => void) | null =
+    null;
+  let firstPayloadReject: ((error: unknown) => void) | null = null;
+  const firstPayload = new Promise<Record<string, unknown>>(
+    (resolve, reject) => {
+      firstPayloadResolve = resolve;
+      firstPayloadReject = reject;
+    }
+  );
+
+  const cleanup = (): void => {
+    active.socket.removeEventListener("message", onMessage);
+    active.socket.removeEventListener("error", onError);
+    active.socket.removeEventListener("close", onClose);
+    input.signal?.removeEventListener("abort", onAbort);
+  };
+
+  const fail = (error: unknown): void => {
+    if (settled) {
+      return;
+    }
+    settled = true;
+    keepSocket = false;
+    failure = error;
+    cleanup();
+    active.release(false);
+    firstPayloadReject?.(error);
+    wakePull();
+  };
+
+  const finish = (): void => {
+    if (settled) {
+      return;
+    }
+    settled = true;
+    cleanup();
+    if (keepSocket && active.cached && responseId) {
+      active.cached.continuation = {
+        lastRequestBody: fullBody,
+        lastResponseId: responseId,
+        lastResponseItems: responseItems,
+      };
+    } else if (active.cached) {
+      active.cached.continuation = null;
+    }
+    active.release(keepSocket);
+    wakePull();
+  };
+
+  const onAbort = (): void => fail(new Error("Request was aborted"));
+
+  const onError = (): void => fail(new Error("WebSocket error"));
+
+  const onClose = (): void => {
+    if (terminal) {
+      wakePull();
+      return;
+    }
+    fail(new Error("WebSocket closed"));
+  };
+
+  const onMessage = (event: unknown): void => {
+    try {
+      const text = decodeMessageData(isObjectRecord(event) ? event.data : null);
+      if (!text) {
+        return;
+      }
+
+      const payload = JSON.parse(text) as unknown;
+      if (!isObjectRecord(payload)) {
+        return;
+      }
+
+      if (
+        payload.type === "response.completed" ||
+        payload.type === "response.done" ||
+        payload.type === "response.incomplete" ||
+        isErrorPayload(payload)
+      ) {
+        terminal = true;
+      }
+      queue.push(payload);
+      if (queue.length === 1) {
+        firstPayloadResolve?.(payload);
+      }
+      wakePull();
+    } catch (error) {
+      fail(error);
+    }
+  };
+
+  active.socket.addEventListener("message", onMessage);
+  active.socket.addEventListener("error", onError);
+  active.socket.addEventListener("close", onClose);
+  input.signal?.addEventListener("abort", onAbort);
+
+  try {
+    active.socket.send(
+      JSON.stringify({ ...requestBody, type: "response.create" })
+    );
+  } catch (error) {
+    fail(error);
+  }
+
+  let first: Record<string, unknown>;
+  try {
+    first = await firstPayload;
+  } catch {
+    return null;
+  }
+
+  if (isErrorPayload(first)) {
+    keepSocket = false;
+    finish();
+    return Response.json(first, { status: readPayloadStatus(first) });
+  }
+
+  const processPayload = (
+    payload: Record<string, unknown>,
+    controller: ReadableStreamDefaultController<Uint8Array>
+  ): void => {
+    const usage = readOpenAiResponsesUsageFromSseEvent(payload);
+    if (usage) {
+      input.onTokenUsage?.(usage);
+    }
+
+    if (isObjectRecord(payload.response)) {
+      responseId = readString(payload.response.id) ?? responseId;
+    }
+    if (payload.type === "response.output_item.done") {
+      responseItems.push(payload.item);
+    }
+
+    controller.enqueue(encodeSse(payload));
+    if (
+      payload.type === "response.completed" ||
+      payload.type === "response.done" ||
+      payload.type === "response.incomplete"
+    ) {
+      terminal = true;
+      finish();
+    } else if (isErrorPayload(payload)) {
+      keepSocket = false;
+      terminal = true;
+      finish();
+    }
+  };
 
   const stream = new ReadableStream<Uint8Array>({
-    start(controller): void {
-      const cleanup = (): void => {
-        active.socket.removeEventListener("message", onMessage);
-        active.socket.removeEventListener("error", onError);
-        active.socket.removeEventListener("close", onClose);
-      };
-      const finish = (): void => {
-        if (settled) {
-          return;
-        }
-        settled = true;
-        cleanup();
-        if (keepSocket && active.cached && responseId) {
-          active.cached.continuation = {
-            lastRequestBody: fullBody,
-            lastResponseId: responseId,
-            lastResponseItems: responseItems,
-          };
-        } else if (active.cached) {
-          active.cached.continuation = null;
-        }
-        active.release(keepSocket);
-        controller.close();
-      };
-      const fail = (error: unknown): void => {
-        if (settled) {
-          return;
-        }
-        settled = true;
-        keepSocket = false;
-        cleanup();
-        active.release(false);
-        controller.error(error);
-      };
-      const onMessage = (event: unknown): void => {
-        try {
-          const text = decodeMessageData(
-            isObjectRecord(event) ? event.data : null
-          );
-          if (!text) {
-            return;
-          }
-
-          const payload = JSON.parse(text) as unknown;
-          if (!isObjectRecord(payload)) {
-            return;
-          }
-
-          const usage = readOpenAiResponsesUsageFromSseEvent(payload);
-          if (usage) {
-            input.onTokenUsage?.(usage);
-          }
-
-          if (isObjectRecord(payload.response)) {
-            responseId = readString(payload.response.id) ?? responseId;
-          }
-          if (payload.type === "response.output_item.done") {
-            responseItems.push(payload.item);
-          }
-
-          controller.enqueue(encodeSse(payload));
-          if (
-            payload.type === "response.completed" ||
-            payload.type === "response.done" ||
-            payload.type === "response.incomplete"
-          ) {
-            finish();
-          } else if (
-            payload.type === "error" ||
-            payload.type === "response.failed"
-          ) {
-            keepSocket = false;
-            finish();
-          }
-        } catch (error) {
-          fail(error);
-        }
-      };
-      const onError = (): void => fail(new Error("WebSocket error"));
-      const onClose = (): void => fail(new Error("WebSocket closed"));
-
-      cleanupStream = cleanup;
-      active.socket.addEventListener("message", onMessage);
-      active.socket.addEventListener("error", onError);
-      active.socket.addEventListener("close", onClose);
-      try {
-        active.socket.send(
-          JSON.stringify({ ...requestBody, type: "response.create" })
-        );
-      } catch (error) {
-        fail(error);
+    async pull(controller): Promise<void> {
+      while (!queue.length && !settled) {
+        await new Promise<void>((resolve) => {
+          wake = resolve;
+        });
       }
+
+      if (queue.length) {
+        const payload = queue.shift();
+        if (payload) {
+          processPayload(payload, controller);
+        }
+        return;
+      }
+
+      if (failure) {
+        controller.error(failure);
+        return;
+      }
+
+      controller.close();
     },
     cancel(): void {
       if (settled) {
         return;
       }
-      settled = true;
-      cleanupStream?.();
-      keepSocket = false;
-      active.release(false);
+      fail(new Error("Response stream was cancelled"));
     },
   });
 

--- a/src/providers/proxies/codex-websocket.ts
+++ b/src/providers/proxies/codex-websocket.ts
@@ -1,0 +1,501 @@
+import {
+  CODEX_RESPONSE_ENDPOINT,
+  CODEX_WEBSOCKET_BETA_HEADER,
+} from "../constants";
+import { readOpenAiResponsesUsageFromSseEvent } from "../../usage/token-usage";
+import type { TokenUsage } from "../../usage/token-usage";
+import { isObjectRecord, readBooleanField } from "../../utils/object";
+
+const SESSION_SOCKET_TTL_MS = 5 * 60 * 1000;
+
+type WebSocketEventType = "open" | "message" | "error" | "close";
+type WebSocketListener = (event: unknown) => void;
+
+type WebSocketLike = {
+  readonly readyState?: number;
+  close(code?: number, reason?: string): void;
+  send(data: string): void;
+  addEventListener(type: WebSocketEventType, listener: WebSocketListener): void;
+  removeEventListener(
+    type: WebSocketEventType,
+    listener: WebSocketListener
+  ): void;
+};
+
+type WebSocketConstructor = new (
+  url: string,
+  protocols?: string | string[] | { headers?: Record<string, string> }
+) => WebSocketLike;
+
+type CodexWebSocketInput = {
+  headers: Headers;
+  bodyJson: Record<string, unknown> | null;
+  accountKey: string;
+  onTokenUsage?: ((usage: TokenUsage) => void) | null;
+  signal?: AbortSignal;
+};
+
+type ContinuationState = {
+  lastRequestBody: Record<string, unknown>;
+  lastResponseId: string;
+  lastResponseItems: unknown[];
+};
+
+type CachedSocket = {
+  socket: WebSocketLike;
+  busy: boolean;
+  idleTimer: ReturnType<typeof setTimeout> | null;
+  continuation: ContinuationState | null;
+};
+
+const socketCache = new Map<string, CachedSocket>();
+
+const resolveCodexWebSocketUrl = (): string => {
+  const url = new URL(CODEX_RESPONSE_ENDPOINT);
+  url.protocol = url.protocol === "http:" ? "ws:" : "wss:";
+  return url.toString();
+};
+
+const headersToRecord = (headers: Headers): Record<string, string> => {
+  const record: Record<string, string> = {};
+  for (const [key, value] of headers) {
+    record[key] = value;
+  }
+  return record;
+};
+
+const createSseResponse = (body: ReadableStream<Uint8Array>): Response =>
+  new Response(body, {
+    headers: {
+      "content-type": "text/event-stream",
+    },
+  });
+
+const readString = (value: unknown): string | null => {
+  if (typeof value !== "string") {
+    return null;
+  }
+
+  const trimmed = value.trim();
+  return trimmed || null;
+};
+
+const readSessionId = (body: Record<string, unknown>, headers: Headers) =>
+  readString(body.prompt_cache_key) ??
+  readString(headers.get("session_id")) ??
+  readString(headers.get("x-client-request-id"));
+
+const isSocketOpen = (socket: WebSocketLike): boolean =>
+  socket.readyState === undefined || socket.readyState === 1;
+
+const closeSocket = (socket: WebSocketLike): void => {
+  try {
+    socket.close(1000, "done");
+  } catch {
+    // Ignore close failures from already-closed sockets.
+  }
+};
+
+const scheduleExpiry = (key: string, cached: CachedSocket): void => {
+  if (cached.idleTimer) {
+    clearTimeout(cached.idleTimer);
+  }
+
+  cached.idleTimer = setTimeout(() => {
+    if (cached.busy) {
+      return;
+    }
+
+    closeSocket(cached.socket);
+    socketCache.delete(key);
+  }, SESSION_SOCKET_TTL_MS);
+};
+
+const getWebSocketConstructor = (): WebSocketConstructor | null => {
+  const websocket = globalThis.WebSocket;
+  return typeof websocket === "function"
+    ? (websocket as unknown as WebSocketConstructor)
+    : null;
+};
+
+const connectWebSocket = (
+  headers: Headers,
+  signal?: AbortSignal
+): Promise<WebSocketLike> => {
+  const WebSocketCtor = getWebSocketConstructor();
+  if (!WebSocketCtor) {
+    return Promise.reject(new Error("WebSocket is not available"));
+  }
+
+  return new Promise((resolve, reject) => {
+    let socket: WebSocketLike;
+    let settled = false;
+
+    const cleanup = (): void => {
+      socket.removeEventListener("open", onOpen);
+      socket.removeEventListener("error", onError);
+      socket.removeEventListener("close", onClose);
+      signal?.removeEventListener("abort", onAbort);
+    };
+    const fail = (error: Error): void => {
+      if (settled) {
+        return;
+      }
+      settled = true;
+      cleanup();
+      reject(error);
+    };
+    const onOpen = (): void => {
+      if (settled) {
+        return;
+      }
+      settled = true;
+      cleanup();
+      resolve(socket);
+    };
+    const onError = (): void => fail(new Error("WebSocket error"));
+    const onClose = (): void => fail(new Error("WebSocket closed"));
+    const onAbort = (): void => {
+      closeSocket(socket);
+      fail(new Error("Request was aborted"));
+    };
+
+    try {
+      socket = new WebSocketCtor(resolveCodexWebSocketUrl(), {
+        headers: headersToRecord(headers),
+      });
+    } catch (error) {
+      reject(error instanceof Error ? error : new Error(String(error)));
+      return;
+    }
+
+    socket.addEventListener("open", onOpen);
+    socket.addEventListener("error", onError);
+    socket.addEventListener("close", onClose);
+    signal?.addEventListener("abort", onAbort);
+  });
+};
+
+const acquireSocket = async (
+  headers: Headers,
+  cacheKey: string | null,
+  signal?: AbortSignal
+): Promise<{
+  socket: WebSocketLike;
+  cached: CachedSocket | null;
+  release(keep: boolean): void;
+}> => {
+  if (!cacheKey) {
+    const socket = await connectWebSocket(headers, signal);
+    return {
+      socket,
+      cached: null,
+      release: () => closeSocket(socket),
+    };
+  }
+
+  const existing = socketCache.get(cacheKey);
+  if (existing) {
+    if (existing.idleTimer) {
+      clearTimeout(existing.idleTimer);
+      existing.idleTimer = null;
+    }
+
+    if (!existing.busy && isSocketOpen(existing.socket)) {
+      existing.busy = true;
+      return {
+        socket: existing.socket,
+        cached: existing,
+        release(keep: boolean): void {
+          if (!(keep && isSocketOpen(existing.socket))) {
+            closeSocket(existing.socket);
+            socketCache.delete(cacheKey);
+            return;
+          }
+          existing.busy = false;
+          scheduleExpiry(cacheKey, existing);
+        },
+      };
+    }
+
+    if (!existing.busy) {
+      closeSocket(existing.socket);
+      socketCache.delete(cacheKey);
+    }
+
+    const socket = await connectWebSocket(headers, signal);
+    return {
+      socket,
+      cached: null,
+      release: () => closeSocket(socket),
+    };
+  }
+
+  const socket = await connectWebSocket(headers, signal);
+  const cached: CachedSocket = {
+    socket,
+    busy: true,
+    idleTimer: null,
+    continuation: null,
+  };
+  socketCache.set(cacheKey, cached);
+  return {
+    socket,
+    cached,
+    release(keep: boolean): void {
+      if (!(keep && isSocketOpen(socket))) {
+        closeSocket(socket);
+        socketCache.delete(cacheKey);
+        return;
+      }
+      cached.busy = false;
+      scheduleExpiry(cacheKey, cached);
+    },
+  };
+};
+
+export const closeCodexWebSocketSessions = (): void => {
+  for (const cached of socketCache.values()) {
+    if (cached.idleTimer) {
+      clearTimeout(cached.idleTimer);
+    }
+    closeSocket(cached.socket);
+  }
+  socketCache.clear();
+};
+
+const withoutContinuationFields = (
+  body: Record<string, unknown>
+): Record<string, unknown> => {
+  const {
+    background: _background,
+    input: _input,
+    previous_response_id: _previous,
+    stream: _stream,
+    ...rest
+  } = body;
+  return rest;
+};
+
+const withoutTransportFields = (
+  body: Record<string, unknown>
+): Record<string, unknown> => {
+  const { background: _background, stream: _stream, ...rest } = body;
+  return rest;
+};
+
+const sameJson = (left: unknown, right: unknown): boolean =>
+  JSON.stringify(left) === JSON.stringify(right);
+
+const buildRequestBody = (
+  body: Record<string, unknown>,
+  cached: CachedSocket | null
+): Record<string, unknown> => {
+  const webSocketBody = withoutTransportFields(body);
+  if (
+    !cached?.continuation ||
+    !Array.isArray(webSocketBody.input) ||
+    webSocketBody.previous_response_id
+  ) {
+    return webSocketBody;
+  }
+
+  const { continuation } = cached;
+  if (
+    !sameJson(
+      withoutContinuationFields(webSocketBody),
+      withoutContinuationFields(continuation.lastRequestBody)
+    ) ||
+    !Array.isArray(continuation.lastRequestBody.input)
+  ) {
+    cached.continuation = null;
+    return webSocketBody;
+  }
+
+  const baseline = [
+    ...continuation.lastRequestBody.input,
+    ...continuation.lastResponseItems,
+  ];
+  const prefix = webSocketBody.input.slice(0, baseline.length);
+  if (!sameJson(prefix, baseline)) {
+    cached.continuation = null;
+    return webSocketBody;
+  }
+
+  return {
+    ...webSocketBody,
+    previous_response_id: continuation.lastResponseId,
+    input: webSocketBody.input.slice(baseline.length),
+  };
+};
+
+const encodeSse = (payload: unknown): Uint8Array =>
+  new TextEncoder().encode(`data: ${JSON.stringify(payload)}\n\n`);
+
+const decodeMessageData = (data: unknown): string | null => {
+  if (typeof data === "string") {
+    return data;
+  }
+  if (data instanceof ArrayBuffer) {
+    return new TextDecoder().decode(data);
+  }
+  if (ArrayBuffer.isView(data)) {
+    return new TextDecoder().decode(data);
+  }
+  return null;
+};
+
+const buildWebSocketHeaders = (
+  headers: Headers,
+  requestId: string
+): Headers => {
+  const nextHeaders = new Headers(headers);
+  nextHeaders.delete("accept");
+  nextHeaders.delete("content-type");
+  nextHeaders.delete("openai-beta");
+  nextHeaders.set("OpenAI-Beta", CODEX_WEBSOCKET_BETA_HEADER);
+  nextHeaders.set("session_id", requestId);
+  nextHeaders.set("x-client-request-id", requestId);
+  return nextHeaders;
+};
+
+export const tryProxyCodexWebSocket = async (
+  input: CodexWebSocketInput
+): Promise<Response | null> => {
+  const body = input.bodyJson;
+  if (!body || readBooleanField(body, "stream") !== true) {
+    return null;
+  }
+
+  const sessionId = readSessionId(body, input.headers);
+  const requestId = sessionId ?? crypto.randomUUID();
+  const cacheKey = sessionId ? `${input.accountKey}:${sessionId}` : null;
+  const headers = buildWebSocketHeaders(input.headers, requestId);
+
+  let acquired: Awaited<ReturnType<typeof acquireSocket>> | null = null;
+  const fullBody = withoutTransportFields(body);
+  let requestBody: Record<string, unknown>;
+  try {
+    acquired = await acquireSocket(headers, cacheKey, input.signal);
+    requestBody = buildRequestBody(body, acquired.cached);
+  } catch {
+    acquired?.release(false);
+    return null;
+  }
+
+  const active = acquired;
+
+  const responseItems: unknown[] = [];
+  let responseId: string | null = null;
+  let keepSocket = true;
+
+  let settled = false;
+  let cleanupStream: (() => void) | null = null;
+
+  const stream = new ReadableStream<Uint8Array>({
+    start(controller): void {
+      const cleanup = (): void => {
+        active.socket.removeEventListener("message", onMessage);
+        active.socket.removeEventListener("error", onError);
+        active.socket.removeEventListener("close", onClose);
+      };
+      const finish = (): void => {
+        if (settled) {
+          return;
+        }
+        settled = true;
+        cleanup();
+        if (keepSocket && active.cached && responseId) {
+          active.cached.continuation = {
+            lastRequestBody: fullBody,
+            lastResponseId: responseId,
+            lastResponseItems: responseItems,
+          };
+        } else if (active.cached) {
+          active.cached.continuation = null;
+        }
+        active.release(keepSocket);
+        controller.close();
+      };
+      const fail = (error: unknown): void => {
+        if (settled) {
+          return;
+        }
+        settled = true;
+        keepSocket = false;
+        cleanup();
+        active.release(false);
+        controller.error(error);
+      };
+      const onMessage = (event: unknown): void => {
+        try {
+          const text = decodeMessageData(
+            isObjectRecord(event) ? event.data : null
+          );
+          if (!text) {
+            return;
+          }
+
+          const payload = JSON.parse(text) as unknown;
+          if (!isObjectRecord(payload)) {
+            return;
+          }
+
+          const usage = readOpenAiResponsesUsageFromSseEvent(payload);
+          if (usage) {
+            input.onTokenUsage?.(usage);
+          }
+
+          if (isObjectRecord(payload.response)) {
+            responseId = readString(payload.response.id) ?? responseId;
+          }
+          if (payload.type === "response.output_item.done") {
+            responseItems.push(payload.item);
+          }
+
+          controller.enqueue(encodeSse(payload));
+          if (
+            payload.type === "response.completed" ||
+            payload.type === "response.done" ||
+            payload.type === "response.incomplete"
+          ) {
+            finish();
+          } else if (
+            payload.type === "error" ||
+            payload.type === "response.failed"
+          ) {
+            keepSocket = false;
+            finish();
+          }
+        } catch (error) {
+          fail(error);
+        }
+      };
+      const onError = (): void => fail(new Error("WebSocket error"));
+      const onClose = (): void => fail(new Error("WebSocket closed"));
+
+      cleanupStream = cleanup;
+      active.socket.addEventListener("message", onMessage);
+      active.socket.addEventListener("error", onError);
+      active.socket.addEventListener("close", onClose);
+      try {
+        active.socket.send(
+          JSON.stringify({ ...requestBody, type: "response.create" })
+        );
+      } catch (error) {
+        fail(error);
+      }
+    },
+    cancel(): void {
+      if (settled) {
+        return;
+      }
+      settled = true;
+      cleanupStream?.();
+      keepSocket = false;
+      active.release(false);
+    },
+  });
+
+  return createSseResponse(stream);
+};

--- a/src/usage/token-usage.ts
+++ b/src/usage/token-usage.ts
@@ -97,7 +97,8 @@ export const readOpenAiResponsesUsageFromSseEvent = (
 
   if (
     payload.type !== "response.completed" &&
-    payload.type !== "response.done"
+    payload.type !== "response.done" &&
+    payload.type !== "response.incomplete"
   ) {
     return null;
   }

--- a/tests/providers/proxy-contract.test.ts
+++ b/tests/providers/proxy-contract.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, test } from "bun:test";
+import { afterEach, describe, expect, test } from "bun:test";
 
 import {
   CLAUDE_REQUIRED_BETA_HEADERS,
@@ -6,6 +6,7 @@ import {
   CODEX_ACCOUNT_ID_HEADER,
   CODEX_ORIGINATOR,
   CODEX_RESPONSE_ENDPOINT,
+  CODEX_WEBSOCKET_BETA_HEADER,
   COPILOT_INITIATOR_HEADER,
   COPILOT_VISION_HEADER,
 } from "../../src/providers/constants";
@@ -15,8 +16,19 @@ import type {
 } from "../../src/providers/metadata";
 import { prepareClaudeProxyRequest } from "../../src/providers/proxies/claude-proxy";
 import { prepareCodexProxyRequest } from "../../src/providers/proxies/codex-proxy";
+import {
+  closeCodexWebSocketSessions,
+  tryProxyCodexWebSocket,
+} from "../../src/providers/proxies/codex-websocket";
 import { prepareCopilotProxyRequest } from "../../src/providers/proxies/copilot-proxy";
 import type { TokenUsage } from "../../src/usage/token-usage";
+
+const originalWebSocket = globalThis.WebSocket;
+
+afterEach(() => {
+  closeCodexWebSocketSessions();
+  globalThis.WebSocket = originalWebSocket;
+});
 
 const createUsageCapture = () => {
   let capturedUsage: TokenUsage | null = null;
@@ -333,6 +345,184 @@ describe("proxy contract: codex", () => {
       cacheReadTokens: 9,
       cacheWriteTokens: 0,
     });
+  });
+
+  test("uses websocket cached delta transport for streaming requests", async () => {
+    const firstAssistantItem = {
+      type: "message",
+      id: "msg_1",
+      role: "assistant",
+      status: "completed",
+      content: [{ type: "output_text", text: "Hello" }],
+    };
+    const secondAssistantItem = {
+      type: "message",
+      id: "msg_2",
+      role: "assistant",
+      status: "completed",
+      content: [{ type: "output_text", text: "Done" }],
+    };
+    const responses = [
+      { id: "resp_1", item: firstAssistantItem },
+      { id: "resp_2", item: secondAssistantItem },
+    ];
+    const sentBodies: unknown[] = [];
+    const constructorHeaders: Record<string, string>[] = [];
+
+    class MockWebSocket {
+      static OPEN = 1;
+      readyState = MockWebSocket.OPEN;
+      private readonly listeners = new Map<
+        string,
+        Set<(event: unknown) => void>
+      >();
+
+      constructor(
+        _url: string,
+        protocols?: string | string[] | { headers?: Record<string, string> }
+      ) {
+        if (
+          protocols &&
+          typeof protocols === "object" &&
+          !Array.isArray(protocols) &&
+          protocols.headers
+        ) {
+          constructorHeaders.push(protocols.headers);
+        }
+        queueMicrotask(() => this.dispatch("open", {}));
+      }
+
+      addEventListener(type: string, listener: (event: unknown) => void): void {
+        const listeners = this.listeners.get(type) ?? new Set();
+        listeners.add(listener);
+        this.listeners.set(type, listeners);
+      }
+
+      removeEventListener(
+        type: string,
+        listener: (event: unknown) => void
+      ): void {
+        this.listeners.get(type)?.delete(listener);
+      }
+
+      send(data: string): void {
+        sentBodies.push(JSON.parse(data) as unknown);
+        const response = responses.shift();
+        if (!response) {
+          throw new Error("Unexpected websocket request");
+        }
+
+        queueMicrotask(() => {
+          for (const event of [
+            { type: "response.created", response: { id: response.id } },
+            { type: "response.output_item.done", item: response.item },
+            {
+              type: "response.completed",
+              response: {
+                id: response.id,
+                usage: {
+                  input_tokens: 10,
+                  output_tokens: 2,
+                  input_tokens_details: { cached_tokens: 3 },
+                },
+              },
+            },
+          ]) {
+            this.dispatch("message", { data: JSON.stringify(event) });
+          }
+        });
+      }
+
+      close(): void {
+        this.readyState = 3;
+      }
+
+      private dispatch(type: string, event: unknown): void {
+        for (const listener of this.listeners.get(type) ?? []) {
+          listener(event);
+        }
+      }
+    }
+
+    globalThis.WebSocket = MockWebSocket as unknown as typeof WebSocket;
+    const headers = new Headers({
+      authorization: "Bearer codex-access",
+      [CODEX_ACCOUNT_ID_HEADER]: "acct_1",
+    });
+    const firstInput = [
+      { role: "user", content: [{ type: "input_text", text: "Say hello" }] },
+    ];
+    const capture = createUsageCapture();
+
+    const first = await tryProxyCodexWebSocket({
+      headers,
+      bodyJson: {
+        model: "gpt-5-codex",
+        stream: true,
+        store: false,
+        prompt_cache_key: "session-1",
+        input: firstInput,
+      },
+      accountKey: "key-1:account-1",
+      onTokenUsage: capture.onTokenUsage,
+    });
+    expect(first).not.toBeNull();
+    await first?.text();
+
+    const second = await tryProxyCodexWebSocket({
+      headers,
+      bodyJson: {
+        model: "gpt-5-codex",
+        stream: true,
+        store: false,
+        prompt_cache_key: "session-1",
+        input: [
+          ...firstInput,
+          firstAssistantItem,
+          { role: "user", content: [{ type: "input_text", text: "Finish" }] },
+        ],
+      },
+      accountKey: "key-1:account-1",
+      onTokenUsage: capture.onTokenUsage,
+    });
+    expect(second).not.toBeNull();
+    await second?.text();
+
+    const firstBody = sentBodies[0] as {
+      input?: unknown[];
+      previous_response_id?: string;
+      stream?: boolean;
+      type?: string;
+    };
+    const secondBody = sentBodies[1] as {
+      input?: unknown[];
+      previous_response_id?: string;
+      stream?: boolean;
+      type?: string;
+    };
+    expect(firstBody.type).toBe("response.create");
+    expect(firstBody.stream).toBeUndefined();
+    expect(firstBody.previous_response_id).toBeUndefined();
+    expect(firstBody.input).toEqual(firstInput);
+    expect(secondBody.previous_response_id).toBe("resp_1");
+    expect(secondBody.input).toEqual([
+      { role: "user", content: [{ type: "input_text", text: "Finish" }] },
+    ]);
+    expect(capture.read()).toEqual({
+      inputTokens: 7,
+      outputTokens: 2,
+      cacheReadTokens: 3,
+      cacheWriteTokens: 0,
+    });
+
+    const lowerHeaderEntries = Object.fromEntries(
+      Object.entries(constructorHeaders[0] ?? {}).map(([key, value]) => [
+        key.toLowerCase(),
+        value,
+      ])
+    );
+    expect(lowerHeaderEntries["openai-beta"]).toBe(CODEX_WEBSOCKET_BETA_HEADER);
+    expect(lowerHeaderEntries.authorization).toBe("Bearer codex-access");
   });
 });
 


### PR DESCRIPTION
## Summary
- route streaming Codex responses through upstream WebSocket by default
- reuse session sockets and send cached continuation deltas when session state is stable
- keep HTTP fallback for setup/connect failures and non-streaming requests

## Tests
- bun test
- bun typecheck
- bun lint