### PR TITLE
fix: accept OpenCode session id header

### DIFF
--- a/src/providers/proxies/codex-websocket.ts
+++ b/src/providers/proxies/codex-websocket.ts
@@ -84,6 +84,7 @@ const readString = (value: unknown): string | null => {
 const readSessionId = (body: Record<string, unknown>, headers: Headers) =>
   readString(body.prompt_cache_key) ??
   readString(headers.get("session_id")) ??
+  readString(headers.get("session-id")) ??
   readString(headers.get("x-client-request-id"));
 
 const isSocketOpen = (socket: WebSocketLike): boolean =>

--- a/tests/providers/proxy-contract.test.ts
+++ b/tests/providers/proxy-contract.test.ts
@@ -448,6 +448,7 @@ describe("proxy contract: codex", () => {
     const headers = new Headers({
       authorization: "Bearer codex-access",
       [CODEX_ACCOUNT_ID_HEADER]: "acct_1",
+      "session-id": "session-1",
     });
     const firstInput = [
       { role: "user", content: [{ type: "input_text", text: "Say hello" }] },
@@ -460,7 +461,6 @@ describe("proxy contract: codex", () => {
         model: "gpt-5-codex",
         stream: true,
         store: false,
-        prompt_cache_key: "session-1",
         input: firstInput,
       },
       accountKey: "key-1:account-1",
@@ -475,7 +475,6 @@ describe("proxy contract: codex", () => {
         model: "gpt-5-codex",
         stream: true,
         store: false,
-        prompt_cache_key: "session-1",
         input: [
           ...firstInput,
           firstAssistantItem,


### PR DESCRIPTION
## Summary
- accept OpenCode's stable \ header for Codex WebSocket session caching
- update WebSocket contract coverage to use the header instead of body prompt_cache_key

## Tests
- bun test tests/providers/proxy-contract.test.ts
- bun typecheck
- bun lint