### PR TITLE
Fix Codex session affinity and WebSocket continuation reuse

### DIFF
--- a/src/http/routes/proxy.ts
+++ b/src/http/routes/proxy.ts
@@ -8,7 +8,11 @@ import {
 } from "../../db/repositories/request-usage";
 import { getRoutableProviderAccount } from "../../domain/providers/provider-service";
 import { prepareClaudeProxyRequest } from "../../providers/proxies/claude-proxy";
-import { prepareCodexProxyRequest } from "../../providers/proxies/codex-proxy";
+import {
+  deriveCodexSessionId,
+  prepareCodexProxyRequest,
+  readCodexSessionId,
+} from "../../providers/proxies/codex-proxy";
 import { tryProxyCodexWebSocket } from "../../providers/proxies/codex-websocket";
 import { prepareCopilotProxyRequest } from "../../providers/proxies/copilot-proxy";
 import type { UsageRequestSource } from "../../usage/request-outcome";
@@ -221,6 +225,13 @@ const proxyRequest = async (
 
   switch (route.provider) {
     case "codex": {
+      const codexSessionId = readCodexSessionId(requestBodyJson, headers);
+      const codexUpstreamSessionId = codexSessionId
+        ? await deriveCodexSessionId(
+            `${apiKeyId}:${account.id}`,
+            codexSessionId
+          )
+        : null;
       const codexProxy = prepareCodexProxyRequest({
         headers,
         accessToken: account.accessToken,
@@ -229,6 +240,7 @@ const proxyRequest = async (
           account.metadata?.provider === "codex" ? account.metadata : null,
         bodyText: requestBody,
         bodyJson: requestBodyJson,
+        sessionId: codexUpstreamSessionId,
         onTokenUsage: usageRecorder.onTokenUsage,
       });
       upstreamUrl = codexProxy.upstreamUrl;
@@ -239,6 +251,8 @@ const proxyRequest = async (
         headers,
         bodyJson: codexProxy.bodyJson,
         accountKey: `${apiKeyId}:${account.id}`,
+        sessionId: codexSessionId,
+        upstreamSessionId: codexUpstreamSessionId,
         onTokenUsage: usageRecorder.onTokenUsage,
         signal: context.req.raw.signal,
       });

--- a/src/providers/proxies/codex-proxy.ts
+++ b/src/providers/proxies/codex-proxy.ts
@@ -36,7 +36,6 @@ export const readCodexSessionId = (
     trimString(headers.get("session_id")) ||
     trimString(headers.get("session-id")) ||
     trimString(headers.get("x-session-affinity")) ||
-    trimString(headers.get("x-client-request-id")) ||
     null
   );
 };
@@ -54,11 +53,16 @@ export const applyCodexSessionHeaders = (
   headers: Headers,
   sessionId: string
 ): void => {
+  clearCodexSessionHeaders(headers);
+  headers.set("session-id", sessionId);
+  headers.set("x-client-request-id", sessionId);
+};
+
+export const clearCodexSessionHeaders = (headers: Headers): void => {
   headers.delete("session_id");
   headers.delete("session-id");
   headers.delete("x-session-affinity");
-  headers.set("session-id", sessionId);
-  headers.set("x-client-request-id", sessionId);
+  headers.delete("x-client-request-id");
 };
 
 export const transformCodexBodyJson = (
@@ -143,6 +147,7 @@ export const prepareCodexProxyRequest = (
   if (accountId) {
     input.headers.set(CODEX_ACCOUNT_ID_HEADER, accountId);
   }
+  clearCodexSessionHeaders(input.headers);
   if (input.sessionId) {
     applyCodexSessionHeaders(input.headers, input.sessionId);
   }

--- a/src/providers/proxies/codex-proxy.ts
+++ b/src/providers/proxies/codex-proxy.ts
@@ -21,8 +21,49 @@ import {
 const trimString = (value: unknown): string =>
   typeof value === "string" ? value.trim() : "";
 
+const toHex = (bytes: Uint8Array): string =>
+  Array.from(bytes, (byte) => byte.toString(16).padStart(2, "0")).join("");
+
+export const readCodexSessionId = (
+  body: unknown,
+  headers: Headers
+): string | null => {
+  const bodySessionId = isObjectRecord(body)
+    ? trimString(body.prompt_cache_key)
+    : "";
+  return (
+    bodySessionId ||
+    trimString(headers.get("session_id")) ||
+    trimString(headers.get("session-id")) ||
+    trimString(headers.get("x-session-affinity")) ||
+    trimString(headers.get("x-client-request-id")) ||
+    null
+  );
+};
+
+export const deriveCodexSessionId = async (
+  accountKey: string,
+  sessionId: string
+): Promise<string> => {
+  const data = new TextEncoder().encode(`${accountKey}:${sessionId}`);
+  const digest = await crypto.subtle.digest("SHA-256", data);
+  return `kleis_${toHex(new Uint8Array(digest)).slice(0, 48)}`;
+};
+
+export const applyCodexSessionHeaders = (
+  headers: Headers,
+  sessionId: string
+): void => {
+  headers.delete("session_id");
+  headers.delete("session-id");
+  headers.delete("x-session-affinity");
+  headers.set("session-id", sessionId);
+  headers.set("x-client-request-id", sessionId);
+};
+
 export const transformCodexBodyJson = (
-  bodyJson: unknown
+  bodyJson: unknown,
+  sessionId?: string | null
 ): JsonObject | null => {
   if (!isObjectRecord(bodyJson)) {
     return null;
@@ -51,6 +92,7 @@ export const transformCodexBodyJson = (
   return {
     ...nextBody,
     instructions,
+    ...(sessionId ? { prompt_cache_key: sessionId } : {}),
   };
 };
 
@@ -74,6 +116,7 @@ type CodexProxyPreparationInput = {
   metadata: CodexAccountMetadata | null;
   bodyText: string;
   bodyJson: unknown;
+  sessionId?: string | null;
   onTokenUsage?: ((usage: TokenUsage) => void) | null;
 };
 
@@ -89,7 +132,7 @@ export const prepareCodexProxyRequest = (
 ): CodexProxyPreparationResult => {
   const isStreamingRequest =
     readBooleanField(input.bodyJson, "stream") === true;
-  const bodyJson = transformCodexBodyJson(input.bodyJson);
+  const bodyJson = transformCodexBodyJson(input.bodyJson, input.sessionId);
 
   input.headers.set("authorization", `Bearer ${input.accessToken}`);
   if (!input.headers.get("originator")) {
@@ -99,6 +142,9 @@ export const prepareCodexProxyRequest = (
   const accountId = input.metadata?.chatgptAccountId ?? input.accountId;
   if (accountId) {
     input.headers.set(CODEX_ACCOUNT_ID_HEADER, accountId);
+  }
+  if (input.sessionId) {
+    applyCodexSessionHeaders(input.headers, input.sessionId);
   }
 
   return {

--- a/src/providers/proxies/codex-websocket.ts
+++ b/src/providers/proxies/codex-websocket.ts
@@ -50,87 +50,9 @@ type CachedSocket = {
   skipNextContinuationStore: boolean;
 };
 
-type CacheDecision = {
-  reason:
-    | "delta"
-    | "no_cached_socket"
-    | "no_continuation"
-    | "explicit_previous_response_id"
-    | "input_not_array"
-    | "cached_input_not_array"
-    | "non_input_mismatch"
-    | "input_shorter_than_baseline"
-    | "prefix_mismatch";
-  currentInputItems: number | null;
-  cachedInputItems: number | null;
-  cachedResponseItems: number | null;
-  baselineItems: number | null;
-  deltaItems: number | null;
-  firstMismatchIndex: number | null;
-  currentNonInputKeys: string[];
-  cachedNonInputKeys: string[];
-  mismatchShapes: MismatchShapes | null;
-};
-
-type SafeItemShape = {
-  type: string | null;
-  role: string | null;
-  hasId: boolean;
-  hasCallId: boolean;
-  contentTypes: string[];
-  summaryCount: number | null;
-  hasEncryptedContent: boolean;
-};
-
-type MismatchShapes = {
-  expected: SafeItemShape;
-  actual: SafeItemShape;
-  responseItemTypes: string[];
-};
-
 const socketCache = new Map<string, CachedSocket>();
 const pendingSocketKeys = new Set<string>();
 const suppressContinuationStoreKeys = new Set<string>();
-
-const emptyCacheDecision = (
-  reason: CacheDecision["reason"],
-  webSocketBody: Record<string, unknown>,
-  cached: CachedSocket | null
-): CacheDecision => ({
-  reason,
-  currentInputItems: Array.isArray(webSocketBody.input)
-    ? webSocketBody.input.length
-    : null,
-  cachedInputItems: Array.isArray(cached?.continuation?.lastRequestBody.input)
-    ? cached.continuation.lastRequestBody.input.length
-    : null,
-  cachedResponseItems: cached?.continuation?.lastResponseItems.length ?? null,
-  baselineItems: null,
-  deltaItems: null,
-  firstMismatchIndex: null,
-  currentNonInputKeys: Object.keys(
-    withoutContinuationFields(webSocketBody)
-  ).sort(),
-  cachedNonInputKeys: Object.keys(
-    cached?.continuation
-      ? withoutContinuationFields(cached.continuation.lastRequestBody)
-      : {}
-  ).sort(),
-  mismatchShapes: null,
-});
-
-const firstJsonMismatchIndex = (
-  left: readonly unknown[],
-  right: readonly unknown[]
-): number | null => {
-  const length = Math.min(left.length, right.length);
-  for (let index = 0; index < length; index++) {
-    if (!sameJson(left[index], right[index])) {
-      return index;
-    }
-  }
-  return left.length === right.length ? null : length;
-};
 
 const resolveCodexWebSocketUrl = (): string => {
   const url = new URL(CODEX_RESPONSE_ENDPOINT);
@@ -527,49 +449,25 @@ const deriveSessionId = async (
 const buildRequestBody = (
   webSocketBody: Record<string, unknown>,
   cached: CachedSocket | null
-): { body: Record<string, unknown>; decision: CacheDecision } => {
+): Record<string, unknown> => {
   if (!cached) {
-    return {
-      body: webSocketBody,
-      decision: emptyCacheDecision("no_cached_socket", webSocketBody, cached),
-    };
+    return webSocketBody;
   }
   if (!cached.continuation) {
-    return {
-      body: webSocketBody,
-      decision: emptyCacheDecision("no_continuation", webSocketBody, cached),
-    };
+    return webSocketBody;
   }
   if (hasOwn(webSocketBody, "previous_response_id")) {
-    return {
-      body: webSocketBody,
-      decision: emptyCacheDecision(
-        "explicit_previous_response_id",
-        webSocketBody,
-        cached
-      ),
-    };
+    return webSocketBody;
   }
   if (!Array.isArray(webSocketBody.input)) {
     cached.continuation = null;
-    return {
-      body: webSocketBody,
-      decision: emptyCacheDecision("input_not_array", webSocketBody, cached),
-    };
+    return webSocketBody;
   }
 
   const { continuation } = cached;
   if (!Array.isArray(continuation.lastRequestBody.input)) {
-    const decision = emptyCacheDecision(
-      "cached_input_not_array",
-      webSocketBody,
-      cached
-    );
     cached.continuation = null;
-    return {
-      body: webSocketBody,
-      decision,
-    };
+    return webSocketBody;
   }
   if (
     !sameJson(
@@ -577,16 +475,8 @@ const buildRequestBody = (
       withoutContinuationFields(continuation.lastRequestBody)
     )
   ) {
-    const decision = emptyCacheDecision(
-      "non_input_mismatch",
-      webSocketBody,
-      cached
-    );
     cached.continuation = null;
-    return {
-      body: webSocketBody,
-      decision,
-    };
+    return webSocketBody;
   }
 
   const baseline = [
@@ -594,19 +484,8 @@ const buildRequestBody = (
     ...continuation.lastResponseItems,
   ];
   if (webSocketBody.input.length < baseline.length) {
-    const decision = {
-      ...emptyCacheDecision(
-        "input_shorter_than_baseline",
-        webSocketBody,
-        cached
-      ),
-      baselineItems: baseline.length,
-    };
     cached.continuation = null;
-    return {
-      body: webSocketBody,
-      decision,
-    };
+    return webSocketBody;
   }
 
   const prefix = webSocketBody.input.slice(0, baseline.length);
@@ -625,53 +504,21 @@ const buildRequestBody = (
     ) {
       const delta = webSocketBody.input.slice(baseline.length);
       return {
-        body: {
-          ...webSocketBody,
-          previous_response_id: continuation.lastResponseId,
-          input: delta,
-        },
-        decision: {
-          ...emptyCacheDecision("delta", webSocketBody, cached),
-          baselineItems: baseline.length,
-          deltaItems: delta.length,
-        },
+        ...webSocketBody,
+        previous_response_id: continuation.lastResponseId,
+        input: delta,
       };
     }
 
-    const firstMismatchIndex = firstJsonMismatchIndex(prefix, baseline);
-    const firstMismatchShapes =
-      firstMismatchIndex === null
-        ? null
-        : mismatchShapes(
-            baseline[firstMismatchIndex],
-            prefix[firstMismatchIndex],
-            continuation.lastResponseItems
-          );
-    const decision = {
-      ...emptyCacheDecision("prefix_mismatch", webSocketBody, cached),
-      baselineItems: baseline.length,
-      firstMismatchIndex,
-      mismatchShapes: firstMismatchShapes,
-    };
     cached.continuation = null;
-    return {
-      body: webSocketBody,
-      decision,
-    };
+    return webSocketBody;
   }
 
   const delta = webSocketBody.input.slice(baseline.length);
   return {
-    body: {
-      ...webSocketBody,
-      previous_response_id: continuation.lastResponseId,
-      input: delta,
-    },
-    decision: {
-      ...emptyCacheDecision("delta", webSocketBody, cached),
-      baselineItems: baseline.length,
-      deltaItems: delta.length,
-    },
+    ...webSocketBody,
+    previous_response_id: continuation.lastResponseId,
+    input: delta,
   };
 };
 
@@ -705,198 +552,6 @@ const isCacheableFinalEvent = (
   (eventType === "response.completed" || eventType === "response.done") &&
   (!responseStatus || responseStatus === "completed");
 
-const safeHeaderNames = (headers: Headers): string[] => {
-  const sensitive = new Set([
-    "authorization",
-    "cookie",
-    "proxy-authorization",
-    "set-cookie",
-    "x-api-key",
-  ]);
-  return Array.from(headers.keys())
-    .map((header) => header.toLowerCase())
-    .filter((header) => !sensitive.has(header))
-    .sort();
-};
-
-const safeString = (value: unknown): string | null =>
-  typeof value === "string" ? value : null;
-
-const SAFE_ITEM_LABELS = new Set([
-  "assistant",
-  "computer_use_call",
-  "file_search_call",
-  "function_call",
-  "function_call_output",
-  "image_generation_call",
-  "input_image",
-  "input_text",
-  "item_reference",
-  "local_shell_call",
-  "mcp_call",
-  "message",
-  "output_text",
-  "reasoning",
-  "summary_text",
-  "system",
-  "user",
-  "web_search_call",
-  "web_search_preview_call",
-]);
-
-const safeItemLabel = (value: unknown): string | null => {
-  const label = safeString(value);
-  if (!label) {
-    return null;
-  }
-  return SAFE_ITEM_LABELS.has(label) ? label : "other";
-};
-
-const safeItemShape = (item: unknown): SafeItemShape => {
-  if (!isObjectRecord(item)) {
-    return {
-      type: null,
-      role: null,
-      hasId: false,
-      hasCallId: false,
-      contentTypes: [],
-      summaryCount: null,
-      hasEncryptedContent: false,
-    };
-  }
-
-  const contentTypes = Array.isArray(item.content)
-    ? item.content
-        .map((content) =>
-          isObjectRecord(content) ? safeItemLabel(content.type) : null
-        )
-        .filter((type) => type !== null)
-    : [];
-
-  return {
-    type: safeItemLabel(item.type),
-    role: safeItemLabel(item.role),
-    hasId: typeof item.id === "string",
-    hasCallId: typeof item.call_id === "string",
-    contentTypes,
-    summaryCount: Array.isArray(item.summary) ? item.summary.length : null,
-    hasEncryptedContent: typeof item.encrypted_content === "string",
-  };
-};
-
-const safeItemType = (item: unknown): string => {
-  if (!isObjectRecord(item)) {
-    return typeof item;
-  }
-  return safeItemLabel(item.type) ?? safeItemLabel(item.role) ?? "object";
-};
-
-const mismatchShapes = (
-  expected: unknown,
-  actual: unknown,
-  responseItems: readonly unknown[]
-): MismatchShapes => ({
-  expected: safeItemShape(expected),
-  actual: safeItemShape(actual),
-  responseItemTypes: responseItems.map(safeItemType),
-});
-
-const readSessionSource = (
-  body: Record<string, unknown>,
-  headers: Headers
-): string => {
-  if (readString(body.prompt_cache_key)) {
-    return "prompt_cache_key";
-  }
-  for (const header of [
-    "session_id",
-    "session-id",
-    "x-session-affinity",
-    "x-client-request-id",
-  ]) {
-    if (readString(headers.get(header))) {
-      return header;
-    }
-  }
-  return "none";
-};
-
-const logCodexWebSocketEvent = (payload: Record<string, unknown>): void => {
-  try {
-    process.stderr.write(`${JSON.stringify(payload)}\n`);
-  } catch {
-    // Diagnostics must never interfere with proxy cleanup.
-  }
-};
-
-const logCodexWebSocketUse = (input: {
-  model: unknown;
-  sessionSource: string;
-  cacheDecision: CacheDecision;
-  inputItems: unknown;
-  requestBody: Record<string, unknown>;
-  incomingHeaders: Headers;
-  firstEventType?: unknown;
-}): void => {
-  logCodexWebSocketEvent({
-    event: "codex_websocket_proxy",
-    model: readString(input.model) ?? null,
-    sessionSource: input.sessionSource,
-    cachedDelta: input.cacheDecision.reason === "delta",
-    cacheDecision: input.cacheDecision.reason,
-    currentInputItems: input.cacheDecision.currentInputItems,
-    cachedInputItems: input.cacheDecision.cachedInputItems,
-    cachedResponseItems: input.cacheDecision.cachedResponseItems,
-    baselineItems: input.cacheDecision.baselineItems,
-    deltaItems: input.cacheDecision.deltaItems,
-    firstMismatchIndex: input.cacheDecision.firstMismatchIndex,
-    mismatchShapes: input.cacheDecision.mismatchShapes,
-    inputItems: Array.isArray(input.inputItems)
-      ? input.inputItems.length
-      : null,
-    hasPreviousResponseId:
-      typeof input.requestBody.previous_response_id === "string",
-    hasPromptCacheKey: typeof input.requestBody.prompt_cache_key === "string",
-    currentNonInputKeys: input.cacheDecision.currentNonInputKeys,
-    cachedNonInputKeys: input.cacheDecision.cachedNonInputKeys,
-    incomingHeaderNames: safeHeaderNames(input.incomingHeaders),
-    incomingSessionHeaders: {
-      session_id: Boolean(readString(input.incomingHeaders.get("session_id"))),
-      sessionId: Boolean(readString(input.incomingHeaders.get("session-id"))),
-      xSessionAffinity: Boolean(
-        readString(input.incomingHeaders.get("x-session-affinity"))
-      ),
-      xClientRequestId: Boolean(
-        readString(input.incomingHeaders.get("x-client-request-id"))
-      ),
-    },
-    firstEventType: readString(input.firstEventType) ?? null,
-  });
-};
-
-const logCodexWebSocketStore = (input: {
-  model: unknown;
-  sessionSource: string;
-  keptSocket: boolean;
-  responseIdPresent: boolean;
-  responseItems: number;
-  terminal: boolean;
-  cached: boolean;
-  finalEventType: unknown;
-}): void => {
-  logCodexWebSocketEvent({
-    event: "codex_websocket_cache_store",
-    model: readString(input.model) ?? null,
-    sessionSource: input.sessionSource,
-    keptSocket: input.keptSocket,
-    responseIdPresent: input.responseIdPresent,
-    responseItems: input.responseItems,
-    terminal: input.terminal,
-    cached: input.cached,
-    finalEventType: readString(input.finalEventType) ?? null,
-  });
-};
-
 const buildWebSocketHeaders = (
   headers: Headers,
   requestId: string
@@ -926,7 +581,6 @@ export const tryProxyCodexWebSocket = async (
   }
 
   const sessionId = readSessionId(body, input.headers);
-  const sessionSource = readSessionSource(body, input.headers);
   const requestId = sessionId
     ? await deriveSessionId(input.accountKey, sessionId)
     : crypto.randomUUID();
@@ -938,12 +592,9 @@ export const tryProxyCodexWebSocket = async (
     sessionId ? { ...body, prompt_cache_key: requestId } : body
   );
   let requestBody: Record<string, unknown>;
-  let cacheDecision: CacheDecision;
   try {
     acquired = await acquireSocket(headers, cacheKey, input.signal);
-    const builtRequest = buildRequestBody(fullBody, acquired.cached);
-    requestBody = builtRequest.body;
-    cacheDecision = builtRequest.decision;
+    requestBody = buildRequestBody(fullBody, acquired.cached);
   } catch {
     acquired?.release(false);
     return null;
@@ -1024,16 +675,6 @@ export const tryProxyCodexWebSocket = async (
       }
       active.cached.skipNextContinuationStore = false;
     }
-    logCodexWebSocketStore({
-      model: requestBody.model,
-      sessionSource,
-      keptSocket: keepSocket,
-      responseIdPresent: Boolean(responseId),
-      responseItems: responseItems.length,
-      terminal,
-      cached: Boolean(active.cached),
-      finalEventType,
-    });
     active.release(keepSocket);
     wakePull();
   };
@@ -1103,16 +744,6 @@ export const tryProxyCodexWebSocket = async (
   } catch {
     return null;
   }
-
-  logCodexWebSocketUse({
-    model: requestBody.model,
-    sessionSource,
-    cacheDecision,
-    inputItems: requestBody.input,
-    requestBody,
-    incomingHeaders: input.headers,
-    firstEventType: first.type,
-  });
 
   if (isErrorPayload(first)) {
     keepSocket = false;

--- a/src/providers/proxies/codex-websocket.ts
+++ b/src/providers/proxies/codex-websocket.ts
@@ -84,6 +84,7 @@ const readString = (value: unknown): string | null => {
 const readSessionId = (body: Record<string, unknown>, headers: Headers) =>
   readString(body.prompt_cache_key) ??
   readString(headers.get("session_id")) ??
+  readString(headers.get("session-id")) ??
   readString(headers.get("x-client-request-id"));
 
 const isSocketOpen = (socket: WebSocketLike): boolean =>

--- a/src/providers/proxies/codex-websocket.ts
+++ b/src/providers/proxies/codex-websocket.ts
@@ -85,6 +85,7 @@ const readSessionId = (body: Record<string, unknown>, headers: Headers) =>
   readString(body.prompt_cache_key) ??
   readString(headers.get("session_id")) ??
   readString(headers.get("session-id")) ??
+  readString(headers.get("x-session-affinity")) ??
   readString(headers.get("x-client-request-id"));
 
 const isSocketOpen = (socket: WebSocketLike): boolean =>

--- a/src/providers/proxies/codex-websocket.ts
+++ b/src/providers/proxies/codex-websocket.ts
@@ -410,17 +410,36 @@ const matchesOptionalField = (
 ): boolean =>
   inputItem[field] === undefined || inputItem[field] === responseItem[field];
 
+const outputTextContent = (content: unknown): unknown[] | null => {
+  if (!Array.isArray(content)) {
+    return null;
+  }
+  const normalized: Array<{ text: unknown; type: "output_text" }> = [];
+  for (const item of content) {
+    if (!isObjectRecord(item) || item.type !== "output_text") {
+      return null;
+    }
+    normalized.push({ type: "output_text", text: item.text });
+  }
+  return normalized;
+};
+
 const matchesMessageInput = (
   responseItem: Record<string, unknown>,
   inputItem: Record<string, unknown>
-): boolean =>
-  (responseItem.role === undefined || responseItem.role === "assistant") &&
-  inputItem.role === "assistant" &&
-  matchesOptionalField(inputItem, responseItem, "id") &&
-  matchesOptionalField(inputItem, responseItem, "status") &&
-  matchesOptionalField(inputItem, responseItem, "type") &&
-  Array.isArray(inputItem.content) &&
-  sameJson(inputItem.content, responseItem.content);
+): boolean => {
+  const responseContent = outputTextContent(responseItem.content);
+  const inputContent = outputTextContent(inputItem.content);
+  return (
+    (responseItem.role === undefined || responseItem.role === "assistant") &&
+    inputItem.role === "assistant" &&
+    matchesOptionalField(inputItem, responseItem, "id") &&
+    matchesOptionalField(inputItem, responseItem, "status") &&
+    matchesOptionalField(inputItem, responseItem, "type") &&
+    Boolean(responseContent) &&
+    sameJson(inputContent, responseContent)
+  );
+};
 
 const matchesFunctionCallInput = (
   responseItem: Record<string, unknown>,
@@ -445,7 +464,7 @@ const matchesReasoningInput = (
   }
   return (
     inputItem.type === "reasoning" &&
-    inputItem.id === responseItem.id &&
+    matchesOptionalField(inputItem, responseItem, "id") &&
     sameJson(inputItem.summary, responseItem.summary ?? []) &&
     sameOptionalJson(
       inputItem.encrypted_content,

--- a/src/providers/proxies/codex-websocket.ts
+++ b/src/providers/proxies/codex-websocket.ts
@@ -359,6 +359,84 @@ const sameJson = (left: unknown, right: unknown): boolean =>
 const hasOwn = (body: Record<string, unknown>, key: string): boolean =>
   Object.hasOwn(body, key);
 
+const sameOptionalJson = (left: unknown, right: unknown): boolean =>
+  (left === undefined && right === undefined) ||
+  (left === undefined && right === null) ||
+  (left === null && right === undefined) ||
+  sameJson(left, right);
+
+const matchesMessageInput = (
+  responseItem: Record<string, unknown>,
+  inputItem: Record<string, unknown>
+): boolean =>
+  inputItem.role === "assistant" &&
+  Array.isArray(inputItem.content) &&
+  sameJson(inputItem.content, responseItem.content);
+
+const matchesFunctionCallInput = (
+  responseItem: Record<string, unknown>,
+  inputItem: Record<string, unknown>
+): boolean =>
+  inputItem.type === "function_call" &&
+  inputItem.call_id === responseItem.call_id &&
+  inputItem.name === responseItem.name &&
+  inputItem.arguments === responseItem.arguments;
+
+const matchesReasoningInput = (
+  responseItem: Record<string, unknown>,
+  inputItem: Record<string, unknown>
+): boolean => {
+  if (typeof responseItem.id !== "string") {
+    return false;
+  }
+  if (inputItem.type === "item_reference") {
+    return inputItem.id === responseItem.id;
+  }
+  return (
+    inputItem.type === "reasoning" &&
+    inputItem.id === responseItem.id &&
+    sameJson(inputItem.summary, responseItem.summary ?? []) &&
+    sameOptionalJson(
+      inputItem.encrypted_content,
+      responseItem.encrypted_content
+    )
+  );
+};
+
+const matchesLoweredResponseItem = (
+  responseItem: unknown,
+  inputItem: unknown
+): boolean => {
+  if (sameJson(responseItem, inputItem)) {
+    return true;
+  }
+  if (!(isObjectRecord(responseItem) && isObjectRecord(inputItem))) {
+    return false;
+  }
+  if (responseItem.type === "message") {
+    return matchesMessageInput(responseItem, inputItem);
+  }
+  if (responseItem.type === "function_call") {
+    return matchesFunctionCallInput(responseItem, inputItem);
+  }
+  if (responseItem.type === "reasoning") {
+    return matchesReasoningInput(responseItem, inputItem);
+  }
+  return false;
+};
+
+const matchesLoweredResponseItems = (
+  responseItems: readonly unknown[],
+  inputItems: readonly unknown[]
+): boolean => {
+  if (responseItems.length !== inputItems.length) {
+    return false;
+  }
+  return responseItems.every((responseItem, index) =>
+    matchesLoweredResponseItem(responseItem, inputItems[index])
+  );
+};
+
 const toHex = (bytes: Uint8Array): string =>
   Array.from(bytes, (byte) => byte.toString(16).padStart(2, "0")).join("");
 
@@ -458,6 +536,33 @@ const buildRequestBody = (
 
   const prefix = webSocketBody.input.slice(0, baseline.length);
   if (!sameJson(prefix, baseline)) {
+    const cachedInput = continuation.lastRequestBody.input;
+    const responsePrefix = webSocketBody.input.slice(
+      cachedInput.length,
+      baseline.length
+    );
+    if (
+      sameJson(webSocketBody.input.slice(0, cachedInput.length), cachedInput) &&
+      matchesLoweredResponseItems(
+        continuation.lastResponseItems,
+        responsePrefix
+      )
+    ) {
+      const delta = webSocketBody.input.slice(baseline.length);
+      return {
+        body: {
+          ...webSocketBody,
+          previous_response_id: continuation.lastResponseId,
+          input: delta,
+        },
+        decision: {
+          ...emptyCacheDecision("delta", webSocketBody, cached),
+          baselineItems: baseline.length,
+          deltaItems: delta.length,
+        },
+      };
+    }
+
     const firstMismatchIndex = firstJsonMismatchIndex(prefix, baseline);
     const decision = {
       ...emptyCacheDecision("prefix_mismatch", webSocketBody, cached),

--- a/src/providers/proxies/codex-websocket.ts
+++ b/src/providers/proxies/codex-websocket.ts
@@ -462,9 +462,14 @@ const matchesReasoningInput = (
   if (inputItem.type === "item_reference") {
     return inputItem.id === responseItem.id;
   }
+  const hasInputId = inputItem.id !== undefined;
+  const hasMatchingEncryptedContent =
+    typeof inputItem.encrypted_content === "string" &&
+    inputItem.encrypted_content === responseItem.encrypted_content;
   return (
     inputItem.type === "reasoning" &&
     matchesOptionalField(inputItem, responseItem, "id") &&
+    (hasInputId || hasMatchingEncryptedContent) &&
     sameJson(inputItem.summary, responseItem.summary ?? []) &&
     sameOptionalJson(
       inputItem.encrypted_content,
@@ -900,6 +905,8 @@ const buildWebSocketHeaders = (
   nextHeaders.delete("accept");
   nextHeaders.delete("content-type");
   nextHeaders.delete("openai-beta");
+  nextHeaders.delete("session-id");
+  nextHeaders.delete("x-session-affinity");
   nextHeaders.set("OpenAI-Beta", CODEX_WEBSOCKET_BETA_HEADER);
   nextHeaders.set("session_id", requestId);
   nextHeaders.set("x-client-request-id", requestId);

--- a/src/providers/proxies/codex-websocket.ts
+++ b/src/providers/proxies/codex-websocket.ts
@@ -49,7 +49,67 @@ type CachedSocket = {
   continuation: ContinuationState | null;
 };
 
+type CacheDecision = {
+  reason:
+    | "delta"
+    | "no_cached_socket"
+    | "no_continuation"
+    | "explicit_previous_response_id"
+    | "input_not_array"
+    | "cached_input_not_array"
+    | "non_input_mismatch"
+    | "input_shorter_than_baseline"
+    | "prefix_mismatch";
+  currentInputItems: number | null;
+  cachedInputItems: number | null;
+  cachedResponseItems: number | null;
+  baselineItems: number | null;
+  deltaItems: number | null;
+  firstMismatchIndex: number | null;
+  currentNonInputKeys: string[];
+  cachedNonInputKeys: string[];
+};
+
 const socketCache = new Map<string, CachedSocket>();
+
+const emptyCacheDecision = (
+  reason: CacheDecision["reason"],
+  webSocketBody: Record<string, unknown>,
+  cached: CachedSocket | null
+): CacheDecision => ({
+  reason,
+  currentInputItems: Array.isArray(webSocketBody.input)
+    ? webSocketBody.input.length
+    : null,
+  cachedInputItems: Array.isArray(cached?.continuation?.lastRequestBody.input)
+    ? cached.continuation.lastRequestBody.input.length
+    : null,
+  cachedResponseItems: cached?.continuation?.lastResponseItems.length ?? null,
+  baselineItems: null,
+  deltaItems: null,
+  firstMismatchIndex: null,
+  currentNonInputKeys: Object.keys(
+    withoutContinuationFields(webSocketBody)
+  ).sort(),
+  cachedNonInputKeys: Object.keys(
+    cached?.continuation
+      ? withoutContinuationFields(cached.continuation.lastRequestBody)
+      : {}
+  ).sort(),
+});
+
+const firstJsonMismatchIndex = (
+  left: readonly unknown[],
+  right: readonly unknown[]
+): number | null => {
+  const length = Math.min(left.length, right.length);
+  for (let index = 0; index < length; index++) {
+    if (!sameJson(left[index], right[index])) {
+      return index;
+    }
+  }
+  return left.length === right.length ? null : length;
+};
 
 const resolveCodexWebSocketUrl = (): string => {
   const url = new URL(CODEX_RESPONSE_ENDPOINT);
@@ -314,41 +374,115 @@ const deriveSessionId = async (
 const buildRequestBody = (
   webSocketBody: Record<string, unknown>,
   cached: CachedSocket | null
-): Record<string, unknown> => {
-  if (
-    !cached?.continuation ||
-    !Array.isArray(webSocketBody.input) ||
-    hasOwn(webSocketBody, "previous_response_id")
-  ) {
-    return webSocketBody;
+): { body: Record<string, unknown>; decision: CacheDecision } => {
+  if (!cached) {
+    return {
+      body: webSocketBody,
+      decision: emptyCacheDecision("no_cached_socket", webSocketBody, cached),
+    };
+  }
+  if (!cached.continuation) {
+    return {
+      body: webSocketBody,
+      decision: emptyCacheDecision("no_continuation", webSocketBody, cached),
+    };
+  }
+  if (hasOwn(webSocketBody, "previous_response_id")) {
+    return {
+      body: webSocketBody,
+      decision: emptyCacheDecision(
+        "explicit_previous_response_id",
+        webSocketBody,
+        cached
+      ),
+    };
+  }
+  if (!Array.isArray(webSocketBody.input)) {
+    cached.continuation = null;
+    return {
+      body: webSocketBody,
+      decision: emptyCacheDecision("input_not_array", webSocketBody, cached),
+    };
   }
 
   const { continuation } = cached;
+  if (!Array.isArray(continuation.lastRequestBody.input)) {
+    const decision = emptyCacheDecision(
+      "cached_input_not_array",
+      webSocketBody,
+      cached
+    );
+    cached.continuation = null;
+    return {
+      body: webSocketBody,
+      decision,
+    };
+  }
   if (
     !sameJson(
       withoutContinuationFields(webSocketBody),
       withoutContinuationFields(continuation.lastRequestBody)
-    ) ||
-    !Array.isArray(continuation.lastRequestBody.input)
+    )
   ) {
+    const decision = emptyCacheDecision(
+      "non_input_mismatch",
+      webSocketBody,
+      cached
+    );
     cached.continuation = null;
-    return webSocketBody;
+    return {
+      body: webSocketBody,
+      decision,
+    };
   }
 
   const baseline = [
     ...continuation.lastRequestBody.input,
     ...continuation.lastResponseItems,
   ];
-  const prefix = webSocketBody.input.slice(0, baseline.length);
-  if (!sameJson(prefix, baseline)) {
+  if (webSocketBody.input.length < baseline.length) {
+    const decision = {
+      ...emptyCacheDecision(
+        "input_shorter_than_baseline",
+        webSocketBody,
+        cached
+      ),
+      baselineItems: baseline.length,
+    };
     cached.continuation = null;
-    return webSocketBody;
+    return {
+      body: webSocketBody,
+      decision,
+    };
   }
 
+  const prefix = webSocketBody.input.slice(0, baseline.length);
+  if (!sameJson(prefix, baseline)) {
+    const firstMismatchIndex = firstJsonMismatchIndex(prefix, baseline);
+    const decision = {
+      ...emptyCacheDecision("prefix_mismatch", webSocketBody, cached),
+      baselineItems: baseline.length,
+      firstMismatchIndex,
+    };
+    cached.continuation = null;
+    return {
+      body: webSocketBody,
+      decision,
+    };
+  }
+
+  const delta = webSocketBody.input.slice(baseline.length);
   return {
-    ...webSocketBody,
-    previous_response_id: continuation.lastResponseId,
-    input: webSocketBody.input.slice(baseline.length),
+    body: {
+      ...webSocketBody,
+      previous_response_id: continuation.lastResponseId,
+      input: delta,
+    },
+    decision: {
+      ...emptyCacheDecision("delta", webSocketBody, cached),
+      baselineItems: baseline.length,
+      deltaItems: delta.length,
+    },
   };
 };
 
@@ -374,6 +508,111 @@ const readPayloadStatus = (payload: Record<string, unknown>): number => {
 
 const isErrorPayload = (payload: Record<string, unknown>): boolean =>
   payload.type === "error" || payload.type === "response.failed";
+
+const safeHeaderNames = (headers: Headers): string[] => {
+  const sensitive = new Set([
+    "authorization",
+    "cookie",
+    "proxy-authorization",
+    "set-cookie",
+    "x-api-key",
+  ]);
+  return Array.from(headers.keys())
+    .map((header) => header.toLowerCase())
+    .filter((header) => !sensitive.has(header))
+    .sort();
+};
+
+const readSessionSource = (
+  body: Record<string, unknown>,
+  headers: Headers
+): string => {
+  if (readString(body.prompt_cache_key)) {
+    return "prompt_cache_key";
+  }
+  for (const header of [
+    "session_id",
+    "session-id",
+    "x-session-affinity",
+    "x-client-request-id",
+  ]) {
+    if (readString(headers.get(header))) {
+      return header;
+    }
+  }
+  return "none";
+};
+
+const logCodexWebSocketEvent = (payload: Record<string, unknown>): void => {
+  process.stderr.write(`${JSON.stringify(payload)}\n`);
+};
+
+const logCodexWebSocketUse = (input: {
+  model: unknown;
+  sessionSource: string;
+  cacheDecision: CacheDecision;
+  inputItems: unknown;
+  requestBody: Record<string, unknown>;
+  incomingHeaders: Headers;
+  firstEventType?: unknown;
+}): void => {
+  logCodexWebSocketEvent({
+    event: "codex_websocket_proxy",
+    model: readString(input.model) ?? null,
+    sessionSource: input.sessionSource,
+    cachedDelta: input.cacheDecision.reason === "delta",
+    cacheDecision: input.cacheDecision.reason,
+    currentInputItems: input.cacheDecision.currentInputItems,
+    cachedInputItems: input.cacheDecision.cachedInputItems,
+    cachedResponseItems: input.cacheDecision.cachedResponseItems,
+    baselineItems: input.cacheDecision.baselineItems,
+    deltaItems: input.cacheDecision.deltaItems,
+    firstMismatchIndex: input.cacheDecision.firstMismatchIndex,
+    inputItems: Array.isArray(input.inputItems)
+      ? input.inputItems.length
+      : null,
+    hasPreviousResponseId:
+      typeof input.requestBody.previous_response_id === "string",
+    hasPromptCacheKey: typeof input.requestBody.prompt_cache_key === "string",
+    currentNonInputKeys: input.cacheDecision.currentNonInputKeys,
+    cachedNonInputKeys: input.cacheDecision.cachedNonInputKeys,
+    incomingHeaderNames: safeHeaderNames(input.incomingHeaders),
+    incomingSessionHeaders: {
+      session_id: Boolean(readString(input.incomingHeaders.get("session_id"))),
+      sessionId: Boolean(readString(input.incomingHeaders.get("session-id"))),
+      xSessionAffinity: Boolean(
+        readString(input.incomingHeaders.get("x-session-affinity"))
+      ),
+      xClientRequestId: Boolean(
+        readString(input.incomingHeaders.get("x-client-request-id"))
+      ),
+    },
+    firstEventType: readString(input.firstEventType) ?? null,
+  });
+};
+
+const logCodexWebSocketStore = (input: {
+  model: unknown;
+  sessionSource: string;
+  keptSocket: boolean;
+  responseIdPresent: boolean;
+  responseItems: number;
+  terminal: boolean;
+  cached: boolean;
+  finalEventType: unknown;
+}): void => {
+  logCodexWebSocketEvent({
+    event: "codex_websocket_cache_store",
+    model: readString(input.model) ?? null,
+    sessionSource: input.sessionSource,
+    keptSocket: input.keptSocket,
+    responseIdPresent: input.responseIdPresent,
+    responseItems: input.responseItems,
+    terminal: input.terminal,
+    cached: input.cached,
+    finalEventType: readString(input.finalEventType) ?? null,
+  });
+};
 
 const buildWebSocketHeaders = (
   headers: Headers,
@@ -402,6 +641,7 @@ export const tryProxyCodexWebSocket = async (
   }
 
   const sessionId = readSessionId(body, input.headers);
+  const sessionSource = readSessionSource(body, input.headers);
   const requestId = sessionId
     ? await deriveSessionId(input.accountKey, sessionId)
     : crypto.randomUUID();
@@ -413,9 +653,12 @@ export const tryProxyCodexWebSocket = async (
     sessionId ? { ...body, prompt_cache_key: requestId } : body
   );
   let requestBody: Record<string, unknown>;
+  let cacheDecision: CacheDecision;
   try {
     acquired = await acquireSocket(headers, cacheKey, input.signal);
-    requestBody = buildRequestBody(fullBody, acquired.cached);
+    const builtRequest = buildRequestBody(fullBody, acquired.cached);
+    requestBody = builtRequest.body;
+    cacheDecision = builtRequest.decision;
   } catch {
     acquired?.release(false);
     return null;
@@ -425,6 +668,7 @@ export const tryProxyCodexWebSocket = async (
 
   const responseItems: unknown[] = [];
   let responseId: string | null = null;
+  let finalEventType: unknown = null;
   let keepSocket = true;
   let settled = false;
   let terminal = false;
@@ -486,6 +730,16 @@ export const tryProxyCodexWebSocket = async (
     } else if (active.cached) {
       active.cached.continuation = null;
     }
+    logCodexWebSocketStore({
+      model: requestBody.model,
+      sessionSource,
+      keptSocket: keepSocket,
+      responseIdPresent: Boolean(responseId),
+      responseItems: responseItems.length,
+      terminal,
+      cached: Boolean(active.cached),
+      finalEventType,
+    });
     active.release(keepSocket);
     wakePull();
   };
@@ -521,6 +775,7 @@ export const tryProxyCodexWebSocket = async (
         isErrorPayload(payload)
       ) {
         terminal = true;
+        finalEventType = payload.type;
       }
       queue.push(payload);
       if (queue.length === 1) {
@@ -552,6 +807,16 @@ export const tryProxyCodexWebSocket = async (
     return null;
   }
 
+  logCodexWebSocketUse({
+    model: requestBody.model,
+    sessionSource,
+    cacheDecision,
+    inputItems: requestBody.input,
+    requestBody,
+    incomingHeaders: input.headers,
+    firstEventType: first.type,
+  });
+
   if (isErrorPayload(first)) {
     keepSocket = false;
     finish();
@@ -581,10 +846,12 @@ export const tryProxyCodexWebSocket = async (
       payload.type === "response.incomplete"
     ) {
       terminal = true;
+      finalEventType = payload.type;
       finish();
     } else if (isErrorPayload(payload)) {
       keepSocket = false;
       terminal = true;
+      finalEventType = payload.type;
       finish();
     }
   };

--- a/src/providers/proxies/codex-websocket.ts
+++ b/src/providers/proxies/codex-websocket.ts
@@ -2,6 +2,11 @@ import {
   CODEX_RESPONSE_ENDPOINT,
   CODEX_WEBSOCKET_BETA_HEADER,
 } from "../constants";
+import {
+  applyCodexSessionHeaders,
+  deriveCodexSessionId,
+  readCodexSessionId,
+} from "./codex-proxy";
 import { readOpenAiResponsesUsageFromSseEvent } from "../../usage/token-usage";
 import type { TokenUsage } from "../../usage/token-usage";
 import { isObjectRecord, readBooleanField } from "../../utils/object";
@@ -32,6 +37,8 @@ type CodexWebSocketInput = {
   headers: Headers;
   bodyJson: Record<string, unknown> | null;
   accountKey: string;
+  sessionId?: string | null;
+  upstreamSessionId?: string | null;
   onTokenUsage?: ((usage: TokenUsage) => void) | null;
   signal?: AbortSignal;
 };
@@ -83,13 +90,6 @@ const readString = (value: unknown): string | null => {
   const trimmed = value.trim();
   return trimmed || null;
 };
-
-const readSessionId = (body: Record<string, unknown>, headers: Headers) =>
-  readString(body.prompt_cache_key) ??
-  readString(headers.get("session_id")) ??
-  readString(headers.get("session-id")) ??
-  readString(headers.get("x-session-affinity")) ??
-  readString(headers.get("x-client-request-id"));
 
 const isSocketOpen = (socket: WebSocketLike): boolean =>
   socket.readyState === undefined || socket.readyState === 1;
@@ -434,18 +434,6 @@ const matchesLoweredResponseItems = (
   );
 };
 
-const toHex = (bytes: Uint8Array): string =>
-  Array.from(bytes, (byte) => byte.toString(16).padStart(2, "0")).join("");
-
-const deriveSessionId = async (
-  accountKey: string,
-  sessionId: string
-): Promise<string> => {
-  const data = new TextEncoder().encode(`${accountKey}:${sessionId}`);
-  const digest = await crypto.subtle.digest("SHA-256", data);
-  return `kleis_${toHex(new Uint8Array(digest)).slice(0, 48)}`;
-};
-
 const buildRequestBody = (
   webSocketBody: Record<string, unknown>,
   cached: CachedSocket | null
@@ -560,11 +548,8 @@ const buildWebSocketHeaders = (
   nextHeaders.delete("accept");
   nextHeaders.delete("content-type");
   nextHeaders.delete("openai-beta");
-  nextHeaders.delete("session-id");
-  nextHeaders.delete("x-session-affinity");
   nextHeaders.set("OpenAI-Beta", CODEX_WEBSOCKET_BETA_HEADER);
-  nextHeaders.set("session_id", requestId);
-  nextHeaders.set("x-client-request-id", requestId);
+  applyCodexSessionHeaders(nextHeaders, requestId);
   return nextHeaders;
 };
 
@@ -580,10 +565,12 @@ export const tryProxyCodexWebSocket = async (
     return null;
   }
 
-  const sessionId = readSessionId(body, input.headers);
-  const requestId = sessionId
-    ? await deriveSessionId(input.accountKey, sessionId)
-    : crypto.randomUUID();
+  const sessionId = input.sessionId ?? readCodexSessionId(body, input.headers);
+  const requestId = input.upstreamSessionId
+    ? input.upstreamSessionId
+    : sessionId
+      ? await deriveCodexSessionId(input.accountKey, sessionId)
+      : crypto.randomUUID();
   const cacheKey = sessionId ? `${input.accountKey}:${sessionId}` : null;
   const headers = buildWebSocketHeaders(input.headers, requestId);
 

--- a/src/providers/proxies/codex-websocket.ts
+++ b/src/providers/proxies/codex-websocket.ts
@@ -47,6 +47,7 @@ type CachedSocket = {
   busy: boolean;
   idleTimer: ReturnType<typeof setTimeout> | null;
   continuation: ContinuationState | null;
+  skipNextContinuationStore: boolean;
 };
 
 type CacheDecision = {
@@ -68,9 +69,28 @@ type CacheDecision = {
   firstMismatchIndex: number | null;
   currentNonInputKeys: string[];
   cachedNonInputKeys: string[];
+  mismatchShapes: MismatchShapes | null;
+};
+
+type SafeItemShape = {
+  type: string | null;
+  role: string | null;
+  hasId: boolean;
+  hasCallId: boolean;
+  contentTypes: string[];
+  summaryCount: number | null;
+  hasEncryptedContent: boolean;
+};
+
+type MismatchShapes = {
+  expected: SafeItemShape;
+  actual: SafeItemShape;
+  responseItemTypes: string[];
 };
 
 const socketCache = new Map<string, CachedSocket>();
+const pendingSocketKeys = new Set<string>();
+const suppressContinuationStoreKeys = new Set<string>();
 
 const emptyCacheDecision = (
   reason: CacheDecision["reason"],
@@ -96,6 +116,7 @@ const emptyCacheDecision = (
       ? withoutContinuationFields(cached.continuation.lastRequestBody)
       : {}
   ).sort(),
+  mismatchShapes: null,
 });
 
 const firstJsonMismatchIndex = (
@@ -273,6 +294,8 @@ const acquireSocket = async (
   const existing = socketCache.get(cacheKey);
   if (existing) {
     if (existing.busy) {
+      existing.continuation = null;
+      existing.skipNextContinuationStore = true;
       throw new Error("Codex WebSocket session is busy");
     }
 
@@ -302,12 +325,27 @@ const acquireSocket = async (
     socketCache.delete(cacheKey);
   }
 
-  const socket = await connectWebSocket(headers, signal);
+  if (pendingSocketKeys.has(cacheKey)) {
+    suppressContinuationStoreKeys.add(cacheKey);
+    throw new Error("Codex WebSocket session is connecting");
+  }
+
+  pendingSocketKeys.add(cacheKey);
+  let socket: WebSocketLike;
+  try {
+    socket = await connectWebSocket(headers, signal);
+  } catch (error) {
+    suppressContinuationStoreKeys.delete(cacheKey);
+    throw error;
+  } finally {
+    pendingSocketKeys.delete(cacheKey);
+  }
   const cached: CachedSocket = {
     socket,
     busy: true,
     idleTimer: null,
     continuation: null,
+    skipNextContinuationStore: suppressContinuationStoreKeys.delete(cacheKey),
   };
   socketCache.set(cacheKey, cached);
   return {
@@ -365,11 +403,22 @@ const sameOptionalJson = (left: unknown, right: unknown): boolean =>
   (left === null && right === undefined) ||
   sameJson(left, right);
 
+const matchesOptionalField = (
+  inputItem: Record<string, unknown>,
+  responseItem: Record<string, unknown>,
+  field: string
+): boolean =>
+  inputItem[field] === undefined || inputItem[field] === responseItem[field];
+
 const matchesMessageInput = (
   responseItem: Record<string, unknown>,
   inputItem: Record<string, unknown>
 ): boolean =>
+  (responseItem.role === undefined || responseItem.role === "assistant") &&
   inputItem.role === "assistant" &&
+  matchesOptionalField(inputItem, responseItem, "id") &&
+  matchesOptionalField(inputItem, responseItem, "status") &&
+  matchesOptionalField(inputItem, responseItem, "type") &&
   Array.isArray(inputItem.content) &&
   sameJson(inputItem.content, responseItem.content);
 
@@ -378,6 +427,8 @@ const matchesFunctionCallInput = (
   inputItem: Record<string, unknown>
 ): boolean =>
   inputItem.type === "function_call" &&
+  matchesOptionalField(inputItem, responseItem, "id") &&
+  matchesOptionalField(inputItem, responseItem, "status") &&
   inputItem.call_id === responseItem.call_id &&
   inputItem.name === responseItem.name &&
   inputItem.arguments === responseItem.arguments;
@@ -564,10 +615,19 @@ const buildRequestBody = (
     }
 
     const firstMismatchIndex = firstJsonMismatchIndex(prefix, baseline);
+    const firstMismatchShapes =
+      firstMismatchIndex === null
+        ? null
+        : mismatchShapes(
+            baseline[firstMismatchIndex],
+            prefix[firstMismatchIndex],
+            continuation.lastResponseItems
+          );
     const decision = {
       ...emptyCacheDecision("prefix_mismatch", webSocketBody, cached),
       baselineItems: baseline.length,
       firstMismatchIndex,
+      mismatchShapes: firstMismatchShapes,
     };
     cached.continuation = null;
     return {
@@ -614,6 +674,13 @@ const readPayloadStatus = (payload: Record<string, unknown>): number => {
 const isErrorPayload = (payload: Record<string, unknown>): boolean =>
   payload.type === "error" || payload.type === "response.failed";
 
+const isCacheableFinalEvent = (
+  eventType: unknown,
+  responseStatus: string | null
+): boolean =>
+  (eventType === "response.completed" || eventType === "response.done") &&
+  (!responseStatus || responseStatus === "completed");
+
 const safeHeaderNames = (headers: Headers): string[] => {
   const sensitive = new Set([
     "authorization",
@@ -627,6 +694,88 @@ const safeHeaderNames = (headers: Headers): string[] => {
     .filter((header) => !sensitive.has(header))
     .sort();
 };
+
+const safeString = (value: unknown): string | null =>
+  typeof value === "string" ? value : null;
+
+const SAFE_ITEM_LABELS = new Set([
+  "assistant",
+  "computer_use_call",
+  "file_search_call",
+  "function_call",
+  "function_call_output",
+  "image_generation_call",
+  "input_image",
+  "input_text",
+  "item_reference",
+  "local_shell_call",
+  "mcp_call",
+  "message",
+  "output_text",
+  "reasoning",
+  "summary_text",
+  "system",
+  "user",
+  "web_search_call",
+  "web_search_preview_call",
+]);
+
+const safeItemLabel = (value: unknown): string | null => {
+  const label = safeString(value);
+  if (!label) {
+    return null;
+  }
+  return SAFE_ITEM_LABELS.has(label) ? label : "other";
+};
+
+const safeItemShape = (item: unknown): SafeItemShape => {
+  if (!isObjectRecord(item)) {
+    return {
+      type: null,
+      role: null,
+      hasId: false,
+      hasCallId: false,
+      contentTypes: [],
+      summaryCount: null,
+      hasEncryptedContent: false,
+    };
+  }
+
+  const contentTypes = Array.isArray(item.content)
+    ? item.content
+        .map((content) =>
+          isObjectRecord(content) ? safeItemLabel(content.type) : null
+        )
+        .filter((type) => type !== null)
+    : [];
+
+  return {
+    type: safeItemLabel(item.type),
+    role: safeItemLabel(item.role),
+    hasId: typeof item.id === "string",
+    hasCallId: typeof item.call_id === "string",
+    contentTypes,
+    summaryCount: Array.isArray(item.summary) ? item.summary.length : null,
+    hasEncryptedContent: typeof item.encrypted_content === "string",
+  };
+};
+
+const safeItemType = (item: unknown): string => {
+  if (!isObjectRecord(item)) {
+    return typeof item;
+  }
+  return safeItemLabel(item.type) ?? safeItemLabel(item.role) ?? "object";
+};
+
+const mismatchShapes = (
+  expected: unknown,
+  actual: unknown,
+  responseItems: readonly unknown[]
+): MismatchShapes => ({
+  expected: safeItemShape(expected),
+  actual: safeItemShape(actual),
+  responseItemTypes: responseItems.map(safeItemType),
+});
 
 const readSessionSource = (
   body: Record<string, unknown>,
@@ -649,7 +798,11 @@ const readSessionSource = (
 };
 
 const logCodexWebSocketEvent = (payload: Record<string, unknown>): void => {
-  process.stderr.write(`${JSON.stringify(payload)}\n`);
+  try {
+    process.stderr.write(`${JSON.stringify(payload)}\n`);
+  } catch {
+    // Diagnostics must never interfere with proxy cleanup.
+  }
 };
 
 const logCodexWebSocketUse = (input: {
@@ -673,6 +826,7 @@ const logCodexWebSocketUse = (input: {
     baselineItems: input.cacheDecision.baselineItems,
     deltaItems: input.cacheDecision.deltaItems,
     firstMismatchIndex: input.cacheDecision.firstMismatchIndex,
+    mismatchShapes: input.cacheDecision.mismatchShapes,
     inputItems: Array.isArray(input.inputItems)
       ? input.inputItems.length
       : null,
@@ -774,6 +928,7 @@ export const tryProxyCodexWebSocket = async (
   const responseItems: unknown[] = [];
   let responseId: string | null = null;
   let finalEventType: unknown = null;
+  let finalResponseStatus: string | null = null;
   let keepSocket = true;
   let settled = false;
   let terminal = false;
@@ -826,14 +981,22 @@ export const tryProxyCodexWebSocket = async (
     }
     settled = true;
     cleanup();
-    if (keepSocket && active.cached && responseId) {
-      active.cached.continuation = {
-        lastRequestBody: fullBody,
-        lastResponseId: responseId,
-        lastResponseItems: responseItems,
-      };
-    } else if (active.cached) {
-      active.cached.continuation = null;
+    if (active.cached) {
+      if (
+        keepSocket &&
+        responseId &&
+        isCacheableFinalEvent(finalEventType, finalResponseStatus) &&
+        !active.cached.skipNextContinuationStore
+      ) {
+        active.cached.continuation = {
+          lastRequestBody: fullBody,
+          lastResponseId: responseId,
+          lastResponseItems: responseItems,
+        };
+      } else {
+        active.cached.continuation = null;
+      }
+      active.cached.skipNextContinuationStore = false;
     }
     logCodexWebSocketStore({
       model: requestBody.model,
@@ -881,6 +1044,9 @@ export const tryProxyCodexWebSocket = async (
       ) {
         terminal = true;
         finalEventType = payload.type;
+        finalResponseStatus = isObjectRecord(payload.response)
+          ? readString(payload.response.status)
+          : null;
       }
       queue.push(payload);
       if (queue.length === 1) {
@@ -952,11 +1118,17 @@ export const tryProxyCodexWebSocket = async (
     ) {
       terminal = true;
       finalEventType = payload.type;
+      finalResponseStatus = isObjectRecord(payload.response)
+        ? readString(payload.response.status)
+        : null;
       finish();
     } else if (isErrorPayload(payload)) {
       keepSocket = false;
       terminal = true;
       finalEventType = payload.type;
+      finalResponseStatus = isObjectRecord(payload.response)
+        ? readString(payload.response.status)
+        : null;
       finish();
     }
   };

--- a/tests/providers/proxy-contract.test.ts
+++ b/tests/providers/proxy-contract.test.ts
@@ -326,6 +326,43 @@ describe("proxy contract: codex", () => {
     );
   });
 
+  test("uses derived session headers and prompt cache key for codex requests", () => {
+    const headers = new Headers({
+      session_id: "raw-session-underscore",
+      "session-id": "raw-session-header",
+      "x-session-affinity": "raw-session-affinity",
+    });
+    const bodyJson = {
+      model: "gpt-5-codex",
+      prompt_cache_key: "raw-prompt-cache-key",
+      input: [
+        {
+          role: "user",
+          content: [{ type: "input_text", text: "hello" }],
+        },
+      ],
+    };
+
+    const result = prepareCodexProxyRequest({
+      headers,
+      accessToken: "codex-access",
+      accountId: "acct-fallback",
+      metadata: null,
+      bodyText: JSON.stringify(bodyJson),
+      bodyJson,
+      sessionId: "kleis_derived_session",
+    });
+
+    const transformed = JSON.parse(result.bodyText) as {
+      prompt_cache_key?: string;
+    };
+    expect(transformed.prompt_cache_key).toBe("kleis_derived_session");
+    expect(headers.get("session_id")).toBeNull();
+    expect(headers.get("x-session-affinity")).toBeNull();
+    expect(headers.get("session-id")).toBe("kleis_derived_session");
+    expect(headers.get("x-client-request-id")).toBe("kleis_derived_session");
+  });
+
   test("removes unsupported token limit params", () => {
     const bodyJson = {
       model: "gpt-5-codex",
@@ -626,11 +663,11 @@ describe("proxy contract: codex", () => {
     );
     expect(lowerHeaderEntries["openai-beta"]).toBe(CODEX_WEBSOCKET_BETA_HEADER);
     expect(lowerHeaderEntries.authorization).toBe("Bearer codex-access");
-    expect(lowerHeaderEntries["session-id"]).toBeUndefined();
+    expect(lowerHeaderEntries.session_id).toBeUndefined();
     expect(lowerHeaderEntries["x-session-affinity"]).toBeUndefined();
-    expect(lowerHeaderEntries.session_id).toMatch(/^kleis_/);
+    expect(lowerHeaderEntries["session-id"]).toMatch(/^kleis_/);
     expect(lowerHeaderEntries["x-client-request-id"]).toBe(
-      lowerHeaderEntries.session_id
+      lowerHeaderEntries["session-id"]
     );
   });
 

--- a/tests/providers/proxy-contract.test.ts
+++ b/tests/providers/proxy-contract.test.ts
@@ -355,6 +355,16 @@ describe("proxy contract: codex", () => {
       status: "completed",
       content: [{ type: "output_text", text: "Hello" }],
     };
+    const firstReasoningItem = {
+      type: "reasoning",
+      id: "rs_1",
+      summary: [],
+      encrypted_content: "encrypted",
+    };
+    const firstAssistantInput = {
+      role: "assistant",
+      content: [{ type: "output_text", text: "Hello" }],
+    };
     const secondAssistantItem = {
       type: "message",
       id: "msg_2",
@@ -363,8 +373,8 @@ describe("proxy contract: codex", () => {
       content: [{ type: "output_text", text: "Done" }],
     };
     const responses = [
-      { id: "resp_1", item: firstAssistantItem },
-      { id: "resp_2", item: secondAssistantItem },
+      { id: "resp_1", items: [firstReasoningItem, firstAssistantItem] },
+      { id: "resp_2", items: [secondAssistantItem] },
     ];
     const sentBodies: unknown[] = [];
     const constructorHeaders: Record<string, string>[] = [];
@@ -415,7 +425,10 @@ describe("proxy contract: codex", () => {
         queueMicrotask(() => {
           for (const event of [
             { type: "response.created", response: { id: response.id } },
-            { type: "response.output_item.done", item: response.item },
+            ...response.items.map((item) => ({
+              type: "response.output_item.done",
+              item,
+            })),
             {
               type: "response.completed",
               response: {
@@ -477,7 +490,13 @@ describe("proxy contract: codex", () => {
         store: false,
         input: [
           ...firstInput,
-          firstAssistantItem,
+          {
+            type: "reasoning",
+            id: "rs_1",
+            summary: [],
+            encrypted_content: "encrypted",
+          },
+          firstAssistantInput,
           { role: "user", content: [{ type: "input_text", text: "Finish" }] },
         ],
       },

--- a/tests/providers/proxy-contract.test.ts
+++ b/tests/providers/proxy-contract.test.ts
@@ -331,6 +331,7 @@ describe("proxy contract: codex", () => {
       session_id: "raw-session-underscore",
       "session-id": "raw-session-header",
       "x-session-affinity": "raw-session-affinity",
+      "x-client-request-id": "raw-request-id",
     });
     const bodyJson = {
       model: "gpt-5-codex",
@@ -361,6 +362,37 @@ describe("proxy contract: codex", () => {
     expect(headers.get("x-session-affinity")).toBeNull();
     expect(headers.get("session-id")).toBe("kleis_derived_session");
     expect(headers.get("x-client-request-id")).toBe("kleis_derived_session");
+  });
+
+  test("does not use x-client-request-id as codex session affinity", () => {
+    const headers = new Headers({
+      "x-client-request-id": "raw-request-id",
+    });
+    const bodyJson = {
+      model: "gpt-5-codex",
+      input: [
+        {
+          role: "user",
+          content: [{ type: "input_text", text: "hello" }],
+        },
+      ],
+    };
+
+    const result = prepareCodexProxyRequest({
+      headers,
+      accessToken: "codex-access",
+      accountId: "acct-fallback",
+      metadata: null,
+      bodyText: JSON.stringify(bodyJson),
+      bodyJson,
+    });
+
+    const transformed = JSON.parse(result.bodyText) as {
+      prompt_cache_key?: string;
+    };
+    expect(transformed.prompt_cache_key).toBeUndefined();
+    expect(headers.get("session-id")).toBeNull();
+    expect(headers.get("x-client-request-id")).toBeNull();
   });
 
   test("removes unsupported token limit params", () => {

--- a/tests/providers/proxy-contract.test.ts
+++ b/tests/providers/proxy-contract.test.ts
@@ -545,6 +545,7 @@ describe("proxy contract: codex", () => {
     const headers = new Headers({
       authorization: "Bearer codex-access",
       [CODEX_ACCOUNT_ID_HEADER]: "acct_1",
+      "session-id": "raw-session-id",
       "x-session-affinity": "session-1",
     });
     const firstInput = [
@@ -625,6 +626,12 @@ describe("proxy contract: codex", () => {
     );
     expect(lowerHeaderEntries["openai-beta"]).toBe(CODEX_WEBSOCKET_BETA_HEADER);
     expect(lowerHeaderEntries.authorization).toBe("Bearer codex-access");
+    expect(lowerHeaderEntries["session-id"]).toBeUndefined();
+    expect(lowerHeaderEntries["x-session-affinity"]).toBeUndefined();
+    expect(lowerHeaderEntries.session_id).toMatch(/^kleis_/);
+    expect(lowerHeaderEntries["x-client-request-id"]).toBe(
+      lowerHeaderEntries.session_id
+    );
   });
 
   test("uses cached delta for raw response item replay", async () => {
@@ -920,6 +927,67 @@ describe("proxy contract: codex", () => {
         output: "done",
       },
     ]);
+  });
+
+  test("falls back for id-less reasoning without encrypted content", async () => {
+    const firstInput = [
+      { role: "user", content: [{ type: "input_text", text: "Think" }] },
+    ];
+    const reasoningItem = {
+      type: "reasoning",
+      id: "rs_1",
+      summary: [{ type: "summary_text", text: "Checked files" }],
+    };
+    const secondInput = [
+      ...firstInput,
+      {
+        type: "reasoning",
+        summary: [{ type: "summary_text", text: "Checked files" }],
+      },
+      { role: "user", content: [{ type: "input_text", text: "Continue" }] },
+    ];
+    const sentBodies: unknown[] = [];
+    installCodexWebSocketMock(
+      [
+        { id: "resp_1", items: [reasoningItem] },
+        { id: "resp_2", items: [] },
+      ],
+      sentBodies
+    );
+
+    const headers = new Headers({
+      authorization: "Bearer codex-access",
+      [CODEX_ACCOUNT_ID_HEADER]: "acct_1",
+      "x-session-affinity": "unsafe-reasoning-session",
+    });
+    const first = await tryProxyCodexWebSocket({
+      headers,
+      bodyJson: {
+        model: "gpt-5-codex",
+        stream: true,
+        input: firstInput,
+      },
+      accountKey: "key-1:account-1",
+    });
+    await first?.text();
+
+    const second = await tryProxyCodexWebSocket({
+      headers,
+      bodyJson: {
+        model: "gpt-5-codex",
+        stream: true,
+        input: secondInput,
+      },
+      accountKey: "key-1:account-1",
+    });
+    await second?.text();
+
+    const secondBody = sentBodies[1] as {
+      input?: unknown[];
+      previous_response_id?: string;
+    };
+    expect(secondBody.previous_response_id).toBeUndefined();
+    expect(secondBody.input).toEqual(secondInput);
   });
 
   test("does not store websocket continuation for incomplete responses", async () => {

--- a/tests/providers/proxy-contract.test.ts
+++ b/tests/providers/proxy-contract.test.ts
@@ -448,6 +448,7 @@ describe("proxy contract: codex", () => {
     const headers = new Headers({
       authorization: "Bearer codex-access",
       [CODEX_ACCOUNT_ID_HEADER]: "acct_1",
+      "session-id": "session-1",
     });
     const firstInput = [
       { role: "user", content: [{ type: "input_text", text: "Say hello" }] },
@@ -460,7 +461,6 @@ describe("proxy contract: codex", () => {
         model: "gpt-5-codex",
         stream: true,
         store: false,
-        prompt_cache_key: "session-1",
         input: firstInput,
       },
       accountKey: "key-1:account-1",
@@ -475,7 +475,6 @@ describe("proxy contract: codex", () => {
         model: "gpt-5-codex",
         stream: true,
         store: false,
-        prompt_cache_key: "session-1",
         input: [
           ...firstInput,
           firstAssistantItem,

--- a/tests/providers/proxy-contract.test.ts
+++ b/tests/providers/proxy-contract.test.ts
@@ -691,6 +691,76 @@ describe("proxy contract: codex", () => {
     ]);
   });
 
+  test("uses cached delta for normalized assistant message content", async () => {
+    const firstInput = [
+      { role: "user", content: [{ type: "input_text", text: "Say hello" }] },
+    ];
+    const firstAssistantItem = {
+      type: "message",
+      id: "msg_1",
+      role: "assistant",
+      status: "completed",
+      content: [
+        {
+          type: "output_text",
+          text: "Hello",
+          annotations: [{ type: "url_citation", url: "https://example.com" }],
+        },
+      ],
+    };
+    const sentBodies: unknown[] = [];
+    installCodexWebSocketMock(
+      [
+        { id: "resp_1", items: [firstAssistantItem] },
+        { id: "resp_2", items: [] },
+      ],
+      sentBodies
+    );
+
+    const headers = new Headers({
+      authorization: "Bearer codex-access",
+      [CODEX_ACCOUNT_ID_HEADER]: "acct_1",
+      "x-session-affinity": "normalized-message-session",
+    });
+    const first = await tryProxyCodexWebSocket({
+      headers,
+      bodyJson: {
+        model: "gpt-5-codex",
+        stream: true,
+        input: firstInput,
+      },
+      accountKey: "key-1:account-1",
+    });
+    await first?.text();
+
+    const second = await tryProxyCodexWebSocket({
+      headers,
+      bodyJson: {
+        model: "gpt-5-codex",
+        stream: true,
+        input: [
+          ...firstInput,
+          {
+            role: "assistant",
+            content: [{ type: "output_text", text: "Hello" }],
+          },
+          { role: "user", content: [{ type: "input_text", text: "Finish" }] },
+        ],
+      },
+      accountKey: "key-1:account-1",
+    });
+    await second?.text();
+
+    const secondBody = sentBodies[1] as {
+      input?: unknown[];
+      previous_response_id?: string;
+    };
+    expect(secondBody.previous_response_id).toBe("resp_1");
+    expect(secondBody.input).toEqual([
+      { role: "user", content: [{ type: "input_text", text: "Finish" }] },
+    ]);
+  });
+
   test("uses cached delta for lowered reasoning references and function calls", async () => {
     const firstInput = [
       { role: "user", content: [{ type: "input_text", text: "Call tool" }] },
@@ -765,6 +835,91 @@ describe("proxy contract: codex", () => {
     };
     expect(secondBody.previous_response_id).toBe("resp_1");
     expect(secondBody.input).toEqual([toolOutput]);
+  });
+
+  test("uses cached delta for encrypted reasoning without replayed id", async () => {
+    const firstInput = [
+      { role: "user", content: [{ type: "input_text", text: "Think" }] },
+    ];
+    const reasoningItem = {
+      type: "reasoning",
+      id: "rs_1",
+      summary: [{ type: "summary_text", text: "Checked files" }],
+      encrypted_content: "encrypted",
+    };
+    const functionCallItem = {
+      type: "function_call",
+      id: "fc_item_1",
+      call_id: "call_1",
+      name: "read_file",
+      arguments: '{"path":"README.md"}',
+    };
+    const sentBodies: unknown[] = [];
+    installCodexWebSocketMock(
+      [
+        { id: "resp_1", items: [reasoningItem, functionCallItem] },
+        { id: "resp_2", items: [] },
+      ],
+      sentBodies
+    );
+
+    const headers = new Headers({
+      authorization: "Bearer codex-access",
+      [CODEX_ACCOUNT_ID_HEADER]: "acct_1",
+      "x-session-affinity": "reasoning-without-id-session",
+    });
+    const first = await tryProxyCodexWebSocket({
+      headers,
+      bodyJson: {
+        model: "gpt-5-codex",
+        stream: true,
+        input: firstInput,
+      },
+      accountKey: "key-1:account-1",
+    });
+    await first?.text();
+
+    const second = await tryProxyCodexWebSocket({
+      headers,
+      bodyJson: {
+        model: "gpt-5-codex",
+        stream: true,
+        input: [
+          ...firstInput,
+          {
+            type: "reasoning",
+            summary: [{ type: "summary_text", text: "Checked files" }],
+            encrypted_content: "encrypted",
+          },
+          {
+            type: "function_call",
+            call_id: "call_1",
+            name: "read_file",
+            arguments: '{"path":"README.md"}',
+          },
+          {
+            type: "function_call_output",
+            call_id: "call_1",
+            output: "done",
+          },
+        ],
+      },
+      accountKey: "key-1:account-1",
+    });
+    await second?.text();
+
+    const secondBody = sentBodies[1] as {
+      input?: unknown[];
+      previous_response_id?: string;
+    };
+    expect(secondBody.previous_response_id).toBe("resp_1");
+    expect(secondBody.input).toEqual([
+      {
+        type: "function_call_output",
+        call_id: "call_1",
+        output: "done",
+      },
+    ]);
   });
 
   test("does not store websocket continuation for incomplete responses", async () => {

--- a/tests/providers/proxy-contract.test.ts
+++ b/tests/providers/proxy-contract.test.ts
@@ -73,6 +73,169 @@ const createSseResponse = (
   );
 };
 
+type MockCodexWebSocketResponse = {
+  id: string;
+  items?: readonly unknown[];
+  terminalType?: "response.completed" | "response.done" | "response.incomplete";
+};
+
+const installCodexWebSocketMock = (
+  responses: MockCodexWebSocketResponse[],
+  sentBodies: unknown[],
+  constructorHeaders: Record<string, string>[] = []
+): void => {
+  class MockWebSocket {
+    static OPEN = 1;
+    readyState = MockWebSocket.OPEN;
+    private readonly listeners = new Map<
+      string,
+      Set<(event: unknown) => void>
+    >();
+
+    constructor(
+      _url: string,
+      protocols?: string | string[] | { headers?: Record<string, string> }
+    ) {
+      if (
+        protocols &&
+        typeof protocols === "object" &&
+        !Array.isArray(protocols) &&
+        protocols.headers
+      ) {
+        constructorHeaders.push(protocols.headers);
+      }
+      queueMicrotask(() => this.dispatch("open", {}));
+    }
+
+    addEventListener(type: string, listener: (event: unknown) => void): void {
+      const listeners = this.listeners.get(type) ?? new Set();
+      listeners.add(listener);
+      this.listeners.set(type, listeners);
+    }
+
+    removeEventListener(
+      type: string,
+      listener: (event: unknown) => void
+    ): void {
+      this.listeners.get(type)?.delete(listener);
+    }
+
+    send(data: string): void {
+      sentBodies.push(JSON.parse(data) as unknown);
+      const response = responses.shift();
+      if (!response) {
+        throw new Error("Unexpected websocket request");
+      }
+
+      queueMicrotask(() => {
+        for (const event of [
+          { type: "response.created", response: { id: response.id } },
+          ...(response.items ?? []).map((item) => ({
+            type: "response.output_item.done",
+            item,
+          })),
+          {
+            type: response.terminalType ?? "response.completed",
+            response: {
+              id: response.id,
+              usage: {
+                input_tokens: 10,
+                output_tokens: 2,
+                input_tokens_details: { cached_tokens: 3 },
+              },
+              status:
+                response.terminalType === "response.incomplete"
+                  ? "incomplete"
+                  : "completed",
+            },
+          },
+        ]) {
+          this.dispatch("message", { data: JSON.stringify(event) });
+        }
+      });
+    }
+
+    close(): void {
+      this.readyState = 3;
+    }
+
+    private dispatch(type: string, event: unknown): void {
+      for (const listener of this.listeners.get(type) ?? []) {
+        listener(event);
+      }
+    }
+  }
+
+  globalThis.WebSocket = MockWebSocket as unknown as typeof WebSocket;
+};
+
+type ManualCodexWebSocket = {
+  dispatch(type: string, event: unknown): void;
+};
+
+const installManualCodexWebSocketMock = (
+  sentBodies: unknown[],
+  options: { autoOpen?: boolean } = {}
+): ManualCodexWebSocket[] => {
+  const sockets: ManualCodexWebSocket[] = [];
+
+  class MockWebSocket {
+    static OPEN = 1;
+    readyState = MockWebSocket.OPEN;
+    private readonly listeners = new Map<
+      string,
+      Set<(event: unknown) => void>
+    >();
+
+    constructor() {
+      sockets.push(this);
+      if (options.autoOpen ?? true) {
+        queueMicrotask(() => this.dispatch("open", {}));
+      }
+    }
+
+    addEventListener(type: string, listener: (event: unknown) => void): void {
+      const listeners = this.listeners.get(type) ?? new Set();
+      listeners.add(listener);
+      this.listeners.set(type, listeners);
+    }
+
+    removeEventListener(
+      type: string,
+      listener: (event: unknown) => void
+    ): void {
+      this.listeners.get(type)?.delete(listener);
+    }
+
+    send(data: string): void {
+      sentBodies.push(JSON.parse(data) as unknown);
+    }
+
+    close(): void {
+      this.readyState = 3;
+    }
+
+    dispatch(type: string, event: unknown): void {
+      for (const listener of this.listeners.get(type) ?? []) {
+        listener(event);
+      }
+    }
+  }
+
+  globalThis.WebSocket = MockWebSocket as unknown as typeof WebSocket;
+  return sockets;
+};
+
+const waitFor = async (predicate: () => boolean): Promise<void> => {
+  for (let attempt = 0; attempt < 50; attempt++) {
+    if (predicate()) {
+      return;
+    }
+    await new Promise((resolve) => setTimeout(resolve, 0));
+  }
+  throw new Error("Timed out waiting for websocket mock");
+};
+
 describe("proxy contract: codex", () => {
   const codexUsageBody = { model: "gpt-5-codex", input: [] };
   const codexStreamingUsageBody = {
@@ -378,86 +541,7 @@ describe("proxy contract: codex", () => {
     ];
     const sentBodies: unknown[] = [];
     const constructorHeaders: Record<string, string>[] = [];
-
-    class MockWebSocket {
-      static OPEN = 1;
-      readyState = MockWebSocket.OPEN;
-      private readonly listeners = new Map<
-        string,
-        Set<(event: unknown) => void>
-      >();
-
-      constructor(
-        _url: string,
-        protocols?: string | string[] | { headers?: Record<string, string> }
-      ) {
-        if (
-          protocols &&
-          typeof protocols === "object" &&
-          !Array.isArray(protocols) &&
-          protocols.headers
-        ) {
-          constructorHeaders.push(protocols.headers);
-        }
-        queueMicrotask(() => this.dispatch("open", {}));
-      }
-
-      addEventListener(type: string, listener: (event: unknown) => void): void {
-        const listeners = this.listeners.get(type) ?? new Set();
-        listeners.add(listener);
-        this.listeners.set(type, listeners);
-      }
-
-      removeEventListener(
-        type: string,
-        listener: (event: unknown) => void
-      ): void {
-        this.listeners.get(type)?.delete(listener);
-      }
-
-      send(data: string): void {
-        sentBodies.push(JSON.parse(data) as unknown);
-        const response = responses.shift();
-        if (!response) {
-          throw new Error("Unexpected websocket request");
-        }
-
-        queueMicrotask(() => {
-          for (const event of [
-            { type: "response.created", response: { id: response.id } },
-            ...response.items.map((item) => ({
-              type: "response.output_item.done",
-              item,
-            })),
-            {
-              type: "response.completed",
-              response: {
-                id: response.id,
-                usage: {
-                  input_tokens: 10,
-                  output_tokens: 2,
-                  input_tokens_details: { cached_tokens: 3 },
-                },
-              },
-            },
-          ]) {
-            this.dispatch("message", { data: JSON.stringify(event) });
-          }
-        });
-      }
-
-      close(): void {
-        this.readyState = 3;
-      }
-
-      private dispatch(type: string, event: unknown): void {
-        for (const listener of this.listeners.get(type) ?? []) {
-          listener(event);
-        }
-      }
-    }
-
-    globalThis.WebSocket = MockWebSocket as unknown as typeof WebSocket;
+    installCodexWebSocketMock(responses, sentBodies, constructorHeaders);
     const headers = new Headers({
       authorization: "Bearer codex-access",
       [CODEX_ACCOUNT_ID_HEADER]: "acct_1",
@@ -541,6 +625,490 @@ describe("proxy contract: codex", () => {
     );
     expect(lowerHeaderEntries["openai-beta"]).toBe(CODEX_WEBSOCKET_BETA_HEADER);
     expect(lowerHeaderEntries.authorization).toBe("Bearer codex-access");
+  });
+
+  test("uses cached delta for raw response item replay", async () => {
+    const firstInput = [
+      { role: "user", content: [{ type: "input_text", text: "Say hello" }] },
+    ];
+    const firstAssistantItem = {
+      type: "message",
+      id: "msg_1",
+      role: "assistant",
+      status: "completed",
+      content: [{ type: "output_text", text: "Hello" }],
+    };
+    const sentBodies: unknown[] = [];
+    installCodexWebSocketMock(
+      [
+        { id: "resp_1", items: [firstAssistantItem] },
+        { id: "resp_2", items: [] },
+      ],
+      sentBodies
+    );
+
+    const headers = new Headers({
+      authorization: "Bearer codex-access",
+      [CODEX_ACCOUNT_ID_HEADER]: "acct_1",
+      "x-session-affinity": "raw-session",
+    });
+    const first = await tryProxyCodexWebSocket({
+      headers,
+      bodyJson: {
+        model: "gpt-5-codex",
+        stream: true,
+        store: false,
+        input: firstInput,
+      },
+      accountKey: "key-1:account-1",
+    });
+    await first?.text();
+
+    const secondInput = [
+      ...firstInput,
+      firstAssistantItem,
+      { role: "user", content: [{ type: "input_text", text: "Finish" }] },
+    ];
+    const second = await tryProxyCodexWebSocket({
+      headers,
+      bodyJson: {
+        model: "gpt-5-codex",
+        stream: true,
+        store: false,
+        input: secondInput,
+      },
+      accountKey: "key-1:account-1",
+    });
+    await second?.text();
+
+    const secondBody = sentBodies[1] as {
+      input?: unknown[];
+      previous_response_id?: string;
+    };
+    expect(secondBody.previous_response_id).toBe("resp_1");
+    expect(secondBody.input).toEqual([
+      { role: "user", content: [{ type: "input_text", text: "Finish" }] },
+    ]);
+  });
+
+  test("uses cached delta for lowered reasoning references and function calls", async () => {
+    const firstInput = [
+      { role: "user", content: [{ type: "input_text", text: "Call tool" }] },
+    ];
+    const reasoningItem = {
+      type: "reasoning",
+      id: "rs_1",
+      summary: [],
+      encrypted_content: "encrypted",
+    };
+    const functionCallItem = {
+      type: "function_call",
+      id: "fc_item_1",
+      call_id: "call_1",
+      name: "read_file",
+      arguments: '{"path":"README.md"}',
+    };
+    const toolOutput = {
+      type: "function_call_output",
+      call_id: "call_1",
+      output: "done",
+    };
+    const sentBodies: unknown[] = [];
+    installCodexWebSocketMock(
+      [
+        { id: "resp_1", items: [reasoningItem, functionCallItem] },
+        { id: "resp_2", items: [] },
+      ],
+      sentBodies
+    );
+
+    const headers = new Headers({
+      authorization: "Bearer codex-access",
+      [CODEX_ACCOUNT_ID_HEADER]: "acct_1",
+      "x-session-affinity": "tool-session",
+    });
+    const first = await tryProxyCodexWebSocket({
+      headers,
+      bodyJson: {
+        model: "gpt-5-codex",
+        stream: true,
+        input: firstInput,
+      },
+      accountKey: "key-1:account-1",
+    });
+    await first?.text();
+
+    const second = await tryProxyCodexWebSocket({
+      headers,
+      bodyJson: {
+        model: "gpt-5-codex",
+        stream: true,
+        input: [
+          ...firstInput,
+          { type: "item_reference", id: "rs_1" },
+          {
+            type: "function_call",
+            call_id: "call_1",
+            name: "read_file",
+            arguments: '{"path":"README.md"}',
+          },
+          toolOutput,
+        ],
+      },
+      accountKey: "key-1:account-1",
+    });
+    await second?.text();
+
+    const secondBody = sentBodies[1] as {
+      input?: unknown[];
+      previous_response_id?: string;
+    };
+    expect(secondBody.previous_response_id).toBe("resp_1");
+    expect(secondBody.input).toEqual([toolOutput]);
+  });
+
+  test("does not store websocket continuation for incomplete responses", async () => {
+    const firstInput = [
+      { role: "user", content: [{ type: "input_text", text: "Start" }] },
+    ];
+    const firstAssistantItem = {
+      type: "message",
+      id: "msg_1",
+      role: "assistant",
+      content: [{ type: "output_text", text: "Partial" }],
+    };
+    const secondInput = [
+      ...firstInput,
+      firstAssistantItem,
+      { role: "user", content: [{ type: "input_text", text: "Continue" }] },
+    ];
+    const sentBodies: unknown[] = [];
+    installCodexWebSocketMock(
+      [
+        {
+          id: "resp_1",
+          items: [firstAssistantItem],
+          terminalType: "response.incomplete",
+        },
+        { id: "resp_2", items: [] },
+      ],
+      sentBodies
+    );
+
+    const headers = new Headers({
+      authorization: "Bearer codex-access",
+      [CODEX_ACCOUNT_ID_HEADER]: "acct_1",
+      "x-session-affinity": "incomplete-session",
+    });
+    const first = await tryProxyCodexWebSocket({
+      headers,
+      bodyJson: {
+        model: "gpt-5-codex",
+        stream: true,
+        input: firstInput,
+      },
+      accountKey: "key-1:account-1",
+    });
+    await first?.text();
+
+    const second = await tryProxyCodexWebSocket({
+      headers,
+      bodyJson: {
+        model: "gpt-5-codex",
+        stream: true,
+        input: secondInput,
+      },
+      accountKey: "key-1:account-1",
+    });
+    await second?.text();
+
+    const secondBody = sentBodies[1] as {
+      input?: unknown[];
+      previous_response_id?: string;
+    };
+    expect(secondBody.previous_response_id).toBeUndefined();
+    expect(secondBody.input).toEqual(secondInput);
+  });
+
+  test("falls back for unmatched hosted tool response items", async () => {
+    const firstInput = [
+      { role: "user", content: [{ type: "input_text", text: "Search" }] },
+    ];
+    const hostedToolItem = {
+      type: "web_search_call",
+      id: "ws_1",
+      status: "completed",
+      action: { query: "example" },
+    };
+    const secondInput = [
+      ...firstInput,
+      {
+        type: "function_call",
+        call_id: "ws_1",
+        name: "web_search",
+        arguments: "{}",
+      },
+      {
+        type: "function_call_output",
+        call_id: "ws_1",
+        output: "{}",
+      },
+      { role: "user", content: [{ type: "input_text", text: "Continue" }] },
+    ];
+    const sentBodies: unknown[] = [];
+    installCodexWebSocketMock(
+      [
+        { id: "resp_1", items: [hostedToolItem] },
+        { id: "resp_2", items: [] },
+      ],
+      sentBodies
+    );
+
+    const headers = new Headers({
+      authorization: "Bearer codex-access",
+      [CODEX_ACCOUNT_ID_HEADER]: "acct_1",
+      "x-session-affinity": "hosted-session",
+    });
+    const first = await tryProxyCodexWebSocket({
+      headers,
+      bodyJson: {
+        model: "gpt-5-codex",
+        stream: true,
+        input: firstInput,
+      },
+      accountKey: "key-1:account-1",
+    });
+    await first?.text();
+
+    const second = await tryProxyCodexWebSocket({
+      headers,
+      bodyJson: {
+        model: "gpt-5-codex",
+        stream: true,
+        input: secondInput,
+      },
+      accountKey: "key-1:account-1",
+    });
+    await second?.text();
+
+    const secondBody = sentBodies[1] as {
+      input?: unknown[];
+      previous_response_id?: string;
+    };
+    expect(secondBody.previous_response_id).toBeUndefined();
+    expect(secondBody.input).toEqual(secondInput);
+  });
+
+  test("invalidates websocket continuation after same-session busy fallback", async () => {
+    const sentBodies: unknown[] = [];
+    const sockets = installManualCodexWebSocketMock(sentBodies);
+    const headers = new Headers({
+      authorization: "Bearer codex-access",
+      [CODEX_ACCOUNT_ID_HEADER]: "acct_1",
+      "x-session-affinity": "busy-session",
+    });
+    const firstInput = [
+      { role: "user", content: [{ type: "input_text", text: "Start" }] },
+    ];
+    const assistantItem = {
+      type: "message",
+      id: "msg_1",
+      role: "assistant",
+      content: [{ type: "output_text", text: "Started" }],
+    };
+    const thirdInput = [
+      ...firstInput,
+      assistantItem,
+      { role: "user", content: [{ type: "input_text", text: "Continue" }] },
+    ];
+
+    const firstPromise = tryProxyCodexWebSocket({
+      headers,
+      bodyJson: {
+        model: "gpt-5-codex",
+        stream: true,
+        input: firstInput,
+      },
+      accountKey: "key-1:account-1",
+    });
+    await waitFor(() => sentBodies.length === 1);
+
+    const busyFallback = await tryProxyCodexWebSocket({
+      headers,
+      bodyJson: {
+        model: "gpt-5-codex",
+        stream: true,
+        input: firstInput,
+      },
+      accountKey: "key-1:account-1",
+    });
+    expect(busyFallback).toBeNull();
+
+    expect(sockets[0]).toBeDefined();
+    const socket = sockets[0];
+    if (!socket) {
+      throw new Error("Missing websocket mock");
+    }
+    socket.dispatch("message", {
+      data: JSON.stringify({
+        type: "response.created",
+        response: { id: "resp_1", status: "completed" },
+      }),
+    });
+    socket.dispatch("message", {
+      data: JSON.stringify({
+        type: "response.output_item.done",
+        item: assistantItem,
+      }),
+    });
+    socket.dispatch("message", {
+      data: JSON.stringify({
+        type: "response.completed",
+        response: { id: "resp_1", status: "completed" },
+      }),
+    });
+    const first = await firstPromise;
+    await first?.text();
+
+    const thirdPromise = tryProxyCodexWebSocket({
+      headers,
+      bodyJson: {
+        model: "gpt-5-codex",
+        stream: true,
+        input: thirdInput,
+      },
+      accountKey: "key-1:account-1",
+    });
+    await waitFor(() => sentBodies.length === 2);
+    socket.dispatch("message", {
+      data: JSON.stringify({
+        type: "response.created",
+        response: { id: "resp_3", status: "completed" },
+      }),
+    });
+    socket.dispatch("message", {
+      data: JSON.stringify({
+        type: "response.completed",
+        response: { id: "resp_3", status: "completed" },
+      }),
+    });
+    const third = await thirdPromise;
+    await third?.text();
+
+    const thirdBody = sentBodies[1] as {
+      input?: unknown[];
+      previous_response_id?: string;
+    };
+    expect(thirdBody.previous_response_id).toBeUndefined();
+    expect(thirdBody.input).toEqual(thirdInput);
+  });
+
+  test("treats same-session websocket connect races as busy", async () => {
+    const sentBodies: unknown[] = [];
+    const sockets = installManualCodexWebSocketMock(sentBodies, {
+      autoOpen: false,
+    });
+    const headers = new Headers({
+      authorization: "Bearer codex-access",
+      [CODEX_ACCOUNT_ID_HEADER]: "acct_1",
+      "x-session-affinity": "connecting-session",
+    });
+    const firstInput = [
+      { role: "user", content: [{ type: "input_text", text: "Start" }] },
+    ];
+    const assistantItem = {
+      type: "message",
+      id: "msg_1",
+      role: "assistant",
+      content: [{ type: "output_text", text: "Started" }],
+    };
+    const thirdInput = [
+      ...firstInput,
+      assistantItem,
+      { role: "user", content: [{ type: "input_text", text: "Continue" }] },
+    ];
+
+    const firstPromise = tryProxyCodexWebSocket({
+      headers,
+      bodyJson: {
+        model: "gpt-5-codex",
+        stream: true,
+        input: firstInput,
+      },
+      accountKey: "key-1:account-1",
+    });
+    await waitFor(() => sockets.length === 1);
+
+    const connectingFallback = await tryProxyCodexWebSocket({
+      headers,
+      bodyJson: {
+        model: "gpt-5-codex",
+        stream: true,
+        input: firstInput,
+      },
+      accountKey: "key-1:account-1",
+    });
+    expect(connectingFallback).toBeNull();
+    expect(sockets).toHaveLength(1);
+
+    const socket = sockets[0];
+    if (!socket) {
+      throw new Error("Missing websocket mock");
+    }
+    socket.dispatch("open", {});
+    await waitFor(() => sentBodies.length === 1);
+    socket.dispatch("message", {
+      data: JSON.stringify({
+        type: "response.created",
+        response: { id: "resp_1", status: "completed" },
+      }),
+    });
+    socket.dispatch("message", {
+      data: JSON.stringify({
+        type: "response.output_item.done",
+        item: assistantItem,
+      }),
+    });
+    socket.dispatch("message", {
+      data: JSON.stringify({
+        type: "response.completed",
+        response: { id: "resp_1", status: "completed" },
+      }),
+    });
+    const first = await firstPromise;
+    await first?.text();
+
+    const thirdPromise = tryProxyCodexWebSocket({
+      headers,
+      bodyJson: {
+        model: "gpt-5-codex",
+        stream: true,
+        input: thirdInput,
+      },
+      accountKey: "key-1:account-1",
+    });
+    await waitFor(() => sentBodies.length === 2);
+    socket.dispatch("message", {
+      data: JSON.stringify({
+        type: "response.created",
+        response: { id: "resp_3", status: "completed" },
+      }),
+    });
+    socket.dispatch("message", {
+      data: JSON.stringify({
+        type: "response.completed",
+        response: { id: "resp_3", status: "completed" },
+      }),
+    });
+    const third = await thirdPromise;
+    await third?.text();
+
+    const thirdBody = sentBodies[1] as {
+      input?: unknown[];
+      previous_response_id?: string;
+    };
+    expect(thirdBody.previous_response_id).toBeUndefined();
+    expect(thirdBody.input).toEqual(thirdInput);
   });
 });
 

--- a/tests/providers/proxy-contract.test.ts
+++ b/tests/providers/proxy-contract.test.ts
@@ -448,7 +448,7 @@ describe("proxy contract: codex", () => {
     const headers = new Headers({
       authorization: "Bearer codex-access",
       [CODEX_ACCOUNT_ID_HEADER]: "acct_1",
-      "session-id": "session-1",
+      "x-session-affinity": "session-1",
     });
     const firstInput = [
       { role: "user", content: [{ type: "input_text", text: "Say hello" }] },


### PR DESCRIPTION
## Summary
- preserves the OpenCode session-affinity fixes off main
- keeps the temporary Codex WebSocket/cache diagnostics for local dev investigation
- includes the experimental lowered-response cache matcher from the latest prod logs

## Notes
- temporary diagnostics should be removed before merge
- main has been reset back to d9ffd8ada12893eb0470807df16a477f0e238e99