### PR TITLE
Fix Codex WebSocket transport hardening

### DIFF
--- a/src/domain/models/models-dev.ts
+++ b/src/domain/models/models-dev.ts
@@ -37,6 +37,7 @@ const CODEX_ALLOWED_OPENAI_MODEL_IDS = new Set([
   "gpt-5.2",
   "gpt-5.2-codex",
   "gpt-5.3-codex",
+  "gpt-5.3-codex-spark",
   "gpt-5.4",
   "gpt-5.4-mini",
   "gpt-5.5",

--- a/src/http/routes/proxy.ts
+++ b/src/http/routes/proxy.ts
@@ -20,7 +20,7 @@ import {
   isTokenUsagePopulated,
   type TokenUsage,
 } from "../../usage/token-usage";
-import { isObjectRecord } from "../../utils/object";
+import { isObjectRecord, readBooleanField } from "../../utils/object";
 import {
   parseModelForProxyRoute,
   proxyRouteTable,
@@ -34,6 +34,76 @@ const proxyErrorResponse = (message: string, type = "proxy_error") => ({
     type,
   },
 });
+
+const CODEX_SSE_HEADER_TIMEOUT_MS = 10_000;
+
+const combineAbortSignals = (
+  signals: readonly (AbortSignal | undefined)[]
+): { signal?: AbortSignal; cleanup(): void } => {
+  const activeSignals = signals.filter(
+    (signal): signal is AbortSignal => signal !== undefined
+  );
+  if (activeSignals.length === 0) {
+    return { cleanup: () => undefined };
+  }
+  if (activeSignals.length === 1) {
+    const signal = activeSignals[0];
+    if (signal) {
+      return { signal, cleanup: () => undefined };
+    }
+    return { cleanup: () => undefined };
+  }
+
+  const controller = new AbortController();
+  const listeners: Array<{ signal: AbortSignal; listener(): void }> = [];
+  const abort = (signal: AbortSignal): void => {
+    if (!controller.signal.aborted) {
+      controller.abort(signal.reason);
+    }
+  };
+
+  for (const signal of activeSignals) {
+    if (signal.aborted) {
+      abort(signal);
+      break;
+    }
+    const listener = (): void => abort(signal);
+    signal.addEventListener("abort", listener, { once: true });
+    listeners.push({ signal, listener });
+  }
+
+  return {
+    signal: controller.signal,
+    cleanup(): void {
+      for (const { signal, listener } of listeners) {
+        signal.removeEventListener("abort", listener);
+      }
+    },
+  };
+};
+
+const createCodexSseHeaderTimeout = (): {
+  signal: AbortSignal;
+  clear(): void;
+  error(): Error | undefined;
+} => {
+  const controller = new AbortController();
+  let error: Error | undefined;
+  const timeout = setTimeout(() => {
+    error = new Error(
+      `Codex SSE response headers timed out after ${CODEX_SSE_HEADER_TIMEOUT_MS}ms`
+    );
+    controller.abort(error);
+  }, CODEX_SSE_HEADER_TIMEOUT_MS);
+
+  return {
+    signal: controller.signal,
+    clear(): void {
+      clearTimeout(timeout);
+    },
+    error: () => error,
+  };
+};
 
 const removeProxyAuthHeaders = (headers: Headers): void => {
   headers.delete("authorization");
@@ -363,6 +433,7 @@ const proxyRequest = async (
   let upstreamUrl = "";
   let responseTransformer: ((response: Response) => Promise<Response>) | null =
     null;
+  let useCodexSseHeaderTimeout = false;
 
   switch (route.provider) {
     case "codex": {
@@ -404,6 +475,8 @@ const proxyRequest = async (
       upstreamUrl = codexProxy.upstreamUrl;
       requestBody = codexProxy.bodyText;
       responseTransformer = codexProxy.transformResponse;
+      useCodexSseHeaderTimeout =
+        readBooleanField(codexProxy.bodyJson, "stream") === true;
       logCodexRequestDiagnostic({
         body: codexProxy.bodyJson,
         headers: codexIncomingHeaders,
@@ -476,6 +549,12 @@ const proxyRequest = async (
 
   let upstreamResponse: Response;
   try {
+    const headerTimeout = useCodexSseHeaderTimeout
+      ? createCodexSseHeaderTimeout()
+      : null;
+    const combinedSignal = headerTimeout
+      ? combineAbortSignals([context.req.raw.signal, headerTimeout.signal])
+      : null;
     const upstreamRequestInit: BunFetchRequestInit = {
       method: context.req.method,
       headers,
@@ -483,7 +562,20 @@ const proxyRequest = async (
       // Provider streams can pause for minutes while a model is thinking.
       timeout: false,
     };
-    upstreamResponse = await fetch(upstreamUrl, upstreamRequestInit);
+    if (combinedSignal?.signal) {
+      upstreamRequestInit.signal = combinedSignal.signal;
+    }
+    try {
+      upstreamResponse = await fetch(upstreamUrl, upstreamRequestInit);
+    } catch (error) {
+      const timeoutError = headerTimeout?.error();
+      throw timeoutError && !context.req.raw.signal.aborted
+        ? timeoutError
+        : error;
+    } finally {
+      combinedSignal?.cleanup();
+      headerTimeout?.clear();
+    }
   } catch (error) {
     usageRecorder.recordImmediate(500);
     throw error;

--- a/src/http/routes/proxy.ts
+++ b/src/http/routes/proxy.ts
@@ -37,51 +37,6 @@ const proxyErrorResponse = (message: string, type = "proxy_error") => ({
 
 const CODEX_SSE_HEADER_TIMEOUT_MS = 10_000;
 
-const combineAbortSignals = (
-  signals: readonly (AbortSignal | undefined)[]
-): { signal?: AbortSignal; cleanup(): void } => {
-  const activeSignals = signals.filter(
-    (signal): signal is AbortSignal => signal !== undefined
-  );
-  if (activeSignals.length === 0) {
-    return { cleanup: () => undefined };
-  }
-  if (activeSignals.length === 1) {
-    const signal = activeSignals[0];
-    if (signal) {
-      return { signal, cleanup: () => undefined };
-    }
-    return { cleanup: () => undefined };
-  }
-
-  const controller = new AbortController();
-  const listeners: Array<{ signal: AbortSignal; listener(): void }> = [];
-  const abort = (signal: AbortSignal): void => {
-    if (!controller.signal.aborted) {
-      controller.abort(signal.reason);
-    }
-  };
-
-  for (const signal of activeSignals) {
-    if (signal.aborted) {
-      abort(signal);
-      break;
-    }
-    const listener = (): void => abort(signal);
-    signal.addEventListener("abort", listener, { once: true });
-    listeners.push({ signal, listener });
-  }
-
-  return {
-    signal: controller.signal,
-    cleanup(): void {
-      for (const { signal, listener } of listeners) {
-        signal.removeEventListener("abort", listener);
-      }
-    },
-  };
-};
-
 const createCodexSseHeaderTimeout = (): {
   signal: AbortSignal;
   clear(): void;
@@ -552,9 +507,6 @@ const proxyRequest = async (
     const headerTimeout = useCodexSseHeaderTimeout
       ? createCodexSseHeaderTimeout()
       : null;
-    const combinedSignal = headerTimeout
-      ? combineAbortSignals([context.req.raw.signal, headerTimeout.signal])
-      : null;
     const upstreamRequestInit: BunFetchRequestInit = {
       method: context.req.method,
       headers,
@@ -562,8 +514,11 @@ const proxyRequest = async (
       // Provider streams can pause for minutes while a model is thinking.
       timeout: false,
     };
-    if (combinedSignal?.signal) {
-      upstreamRequestInit.signal = combinedSignal.signal;
+    if (headerTimeout) {
+      upstreamRequestInit.signal = AbortSignal.any([
+        context.req.raw.signal,
+        headerTimeout.signal,
+      ]);
     }
     try {
       upstreamResponse = await fetch(upstreamUrl, upstreamRequestInit);
@@ -573,7 +528,6 @@ const proxyRequest = async (
         ? timeoutError
         : error;
     } finally {
-      combinedSignal?.cleanup();
       headerTimeout?.clear();
     }
   } catch (error) {

--- a/src/http/routes/proxy.ts
+++ b/src/http/routes/proxy.ts
@@ -83,147 +83,6 @@ const runInBackground = (promise: Promise<unknown>): void => {
   promise.catch(() => undefined);
 };
 
-const readString = (value: unknown): string | null => {
-  if (typeof value !== "string") {
-    return null;
-  }
-  const trimmed = value.trim();
-  return trimmed || null;
-};
-
-const arrayLength = (value: unknown): number | null =>
-  Array.isArray(value) ? value.length : null;
-
-const countByStringField = (
-  values: readonly unknown[],
-  field: string
-): Record<string, number> => {
-  const counts: Record<string, number> = {};
-  for (const value of values) {
-    const key = isObjectRecord(value) ? readString(value[field]) : null;
-    counts[key ?? "missing"] = (counts[key ?? "missing"] ?? 0) + 1;
-  }
-  return counts;
-};
-
-const readContentTypes = (value: unknown): string[] | null => {
-  if (!isObjectRecord(value) || !Array.isArray(value.content)) {
-    return null;
-  }
-  return value.content.map((item) => {
-    if (!isObjectRecord(item)) {
-      return typeof item;
-    }
-    return readString(item.type) ?? "missing";
-  });
-};
-
-const summarizeInputShape = (input: unknown) => {
-  if (!Array.isArray(input)) {
-    return {
-      inputItems: null,
-      inputTypes: {},
-      inputRoles: {},
-      lastItem: null,
-    };
-  }
-
-  const last = input.at(-1);
-  return {
-    inputItems: input.length,
-    inputTypes: countByStringField(input, "type"),
-    inputRoles: countByStringField(input, "role"),
-    lastItem: isObjectRecord(last)
-      ? {
-          type: readString(last.type),
-          role: readString(last.role),
-          keys: Object.keys(last).sort(),
-          contentTypes: readContentTypes(last),
-        }
-      : null,
-  };
-};
-
-const readCodexSessionSource = (body: unknown, headers: Headers): string => {
-  if (isObjectRecord(body) && readString(body.prompt_cache_key)) {
-    return "prompt_cache_key";
-  }
-  for (const header of ["session_id", "session-id", "x-session-affinity"]) {
-    if (readString(headers.get(header))) {
-      return header;
-    }
-  }
-  return "none";
-};
-
-const logCodexCompactionDiagnostic = (
-  payload: Record<string, unknown>
-): void => {
-  process.stderr.write(`${JSON.stringify(payload)}\n`);
-};
-
-const logCodexRequestDiagnostic = (input: {
-  body: unknown;
-  headers: Headers;
-  sessionHash: string | null;
-  sessionSource: string;
-}): void => {
-  const body = isObjectRecord(input.body) ? input.body : null;
-  const inputShape = summarizeInputShape(body?.input);
-  logCodexCompactionDiagnostic({
-    event: "codex_compaction_request",
-    model: readString(body?.model),
-    sessionHash: input.sessionHash,
-    sessionSource: input.sessionSource,
-    stream: body ? body.stream === true : null,
-    background: body ? body.background === true : null,
-    store: body ? body.store === true : null,
-    hasPreviousResponseId: typeof body?.previous_response_id === "string",
-    hasPromptCacheKey: typeof body?.prompt_cache_key === "string",
-    topLevelKeys: body ? Object.keys(body).sort() : [],
-    includeItems: arrayLength(body?.include),
-    tools: arrayLength(body?.tools),
-    hasInstructions: typeof body?.instructions === "string",
-    reasoningKeys: isObjectRecord(body?.reasoning)
-      ? Object.keys(body.reasoning).sort()
-      : null,
-    textKeys: isObjectRecord(body?.text) ? Object.keys(body.text).sort() : null,
-    incomingSessionHeaders: {
-      session_id: Boolean(readString(input.headers.get("session_id"))),
-      sessionId: Boolean(readString(input.headers.get("session-id"))),
-      xSessionAffinity: Boolean(
-        readString(input.headers.get("x-session-affinity"))
-      ),
-      xClientRequestId: Boolean(
-        readString(input.headers.get("x-client-request-id"))
-      ),
-    },
-    ...inputShape,
-  });
-};
-
-const logCodexUsageDiagnostic = (input: {
-  model: string;
-  sessionHash: string | null;
-  sessionSource: string;
-  usage: TokenUsage;
-}): void => {
-  logCodexCompactionDiagnostic({
-    event: "codex_compaction_usage",
-    model: input.model,
-    sessionHash: input.sessionHash,
-    sessionSource: input.sessionSource,
-    inputTokens: input.usage.inputTokens,
-    cacheReadTokens: input.usage.cacheReadTokens,
-    cacheWriteTokens: input.usage.cacheWriteTokens,
-    totalInputTokens:
-      input.usage.inputTokens +
-      input.usage.cacheReadTokens +
-      input.usage.cacheWriteTokens,
-    outputTokens: input.usage.outputTokens,
-  });
-};
-
 type BunFetchRequestInit = RequestInit & {
   timeout?: number | false;
 };
@@ -399,22 +258,8 @@ const proxyRequest = async (
             codexSessionId
           )
         : null;
-      const codexSessionSource = readCodexSessionSource(
-        requestBodyJson,
-        headers
-      );
-      const codexSessionHash = codexUpstreamSessionId
-        ? codexUpstreamSessionId.replace(/^kleis_/, "").slice(0, 16)
-        : null;
-      const codexIncomingHeaders = new Headers(headers);
       const onCodexTokenUsage = (tokenUsage: TokenUsage): void => {
         usageRecorder.onTokenUsage(tokenUsage);
-        logCodexUsageDiagnostic({
-          model: usageModel,
-          sessionHash: codexSessionHash,
-          sessionSource: codexSessionSource,
-          usage: tokenUsage,
-        });
       };
       const codexProxy = prepareCodexProxyRequest({
         headers,
@@ -432,12 +277,6 @@ const proxyRequest = async (
       responseTransformer = codexProxy.transformResponse;
       useCodexSseHeaderTimeout =
         readBooleanField(codexProxy.bodyJson, "stream") === true;
-      logCodexRequestDiagnostic({
-        body: codexProxy.bodyJson,
-        headers: codexIncomingHeaders,
-        sessionHash: codexSessionHash,
-        sessionSource: codexSessionSource,
-      });
 
       const webSocketResponse = await tryProxyCodexWebSocket({
         headers,

--- a/src/http/routes/proxy.ts
+++ b/src/http/routes/proxy.ts
@@ -258,9 +258,6 @@ const proxyRequest = async (
             codexSessionId
           )
         : null;
-      const onCodexTokenUsage = (tokenUsage: TokenUsage): void => {
-        usageRecorder.onTokenUsage(tokenUsage);
-      };
       const codexProxy = prepareCodexProxyRequest({
         headers,
         accessToken: account.accessToken,
@@ -270,7 +267,7 @@ const proxyRequest = async (
         bodyText: requestBody,
         bodyJson: requestBodyJson,
         sessionId: codexUpstreamSessionId,
-        onTokenUsage: onCodexTokenUsage,
+        onTokenUsage: usageRecorder.onTokenUsage,
       });
       upstreamUrl = codexProxy.upstreamUrl;
       requestBody = codexProxy.bodyText;
@@ -284,7 +281,7 @@ const proxyRequest = async (
         accountKey: `${apiKeyId}:${account.id}`,
         sessionId: codexSessionId,
         upstreamSessionId: codexUpstreamSessionId,
-        onTokenUsage: onCodexTokenUsage,
+        onTokenUsage: usageRecorder.onTokenUsage,
         signal: context.req.raw.signal,
       });
       if (webSocketResponse) {

--- a/src/http/routes/proxy.ts
+++ b/src/http/routes/proxy.ts
@@ -58,6 +58,147 @@ const runInBackground = (promise: Promise<unknown>): void => {
   promise.catch(() => undefined);
 };
 
+const readString = (value: unknown): string | null => {
+  if (typeof value !== "string") {
+    return null;
+  }
+  const trimmed = value.trim();
+  return trimmed || null;
+};
+
+const arrayLength = (value: unknown): number | null =>
+  Array.isArray(value) ? value.length : null;
+
+const countByStringField = (
+  values: readonly unknown[],
+  field: string
+): Record<string, number> => {
+  const counts: Record<string, number> = {};
+  for (const value of values) {
+    const key = isObjectRecord(value) ? readString(value[field]) : null;
+    counts[key ?? "missing"] = (counts[key ?? "missing"] ?? 0) + 1;
+  }
+  return counts;
+};
+
+const readContentTypes = (value: unknown): string[] | null => {
+  if (!isObjectRecord(value) || !Array.isArray(value.content)) {
+    return null;
+  }
+  return value.content.map((item) => {
+    if (!isObjectRecord(item)) {
+      return typeof item;
+    }
+    return readString(item.type) ?? "missing";
+  });
+};
+
+const summarizeInputShape = (input: unknown) => {
+  if (!Array.isArray(input)) {
+    return {
+      inputItems: null,
+      inputTypes: {},
+      inputRoles: {},
+      lastItem: null,
+    };
+  }
+
+  const last = input.at(-1);
+  return {
+    inputItems: input.length,
+    inputTypes: countByStringField(input, "type"),
+    inputRoles: countByStringField(input, "role"),
+    lastItem: isObjectRecord(last)
+      ? {
+          type: readString(last.type),
+          role: readString(last.role),
+          keys: Object.keys(last).sort(),
+          contentTypes: readContentTypes(last),
+        }
+      : null,
+  };
+};
+
+const readCodexSessionSource = (body: unknown, headers: Headers): string => {
+  if (isObjectRecord(body) && readString(body.prompt_cache_key)) {
+    return "prompt_cache_key";
+  }
+  for (const header of ["session_id", "session-id", "x-session-affinity"]) {
+    if (readString(headers.get(header))) {
+      return header;
+    }
+  }
+  return "none";
+};
+
+const logCodexCompactionDiagnostic = (
+  payload: Record<string, unknown>
+): void => {
+  process.stderr.write(`${JSON.stringify(payload)}\n`);
+};
+
+const logCodexRequestDiagnostic = (input: {
+  body: unknown;
+  headers: Headers;
+  sessionHash: string | null;
+  sessionSource: string;
+}): void => {
+  const body = isObjectRecord(input.body) ? input.body : null;
+  const inputShape = summarizeInputShape(body?.input);
+  logCodexCompactionDiagnostic({
+    event: "codex_compaction_request",
+    model: readString(body?.model),
+    sessionHash: input.sessionHash,
+    sessionSource: input.sessionSource,
+    stream: body ? body.stream === true : null,
+    background: body ? body.background === true : null,
+    store: body ? body.store === true : null,
+    hasPreviousResponseId: typeof body?.previous_response_id === "string",
+    hasPromptCacheKey: typeof body?.prompt_cache_key === "string",
+    topLevelKeys: body ? Object.keys(body).sort() : [],
+    includeItems: arrayLength(body?.include),
+    tools: arrayLength(body?.tools),
+    hasInstructions: typeof body?.instructions === "string",
+    reasoningKeys: isObjectRecord(body?.reasoning)
+      ? Object.keys(body.reasoning).sort()
+      : null,
+    textKeys: isObjectRecord(body?.text) ? Object.keys(body.text).sort() : null,
+    incomingSessionHeaders: {
+      session_id: Boolean(readString(input.headers.get("session_id"))),
+      sessionId: Boolean(readString(input.headers.get("session-id"))),
+      xSessionAffinity: Boolean(
+        readString(input.headers.get("x-session-affinity"))
+      ),
+      xClientRequestId: Boolean(
+        readString(input.headers.get("x-client-request-id"))
+      ),
+    },
+    ...inputShape,
+  });
+};
+
+const logCodexUsageDiagnostic = (input: {
+  model: string;
+  sessionHash: string | null;
+  sessionSource: string;
+  usage: TokenUsage;
+}): void => {
+  logCodexCompactionDiagnostic({
+    event: "codex_compaction_usage",
+    model: input.model,
+    sessionHash: input.sessionHash,
+    sessionSource: input.sessionSource,
+    inputTokens: input.usage.inputTokens,
+    cacheReadTokens: input.usage.cacheReadTokens,
+    cacheWriteTokens: input.usage.cacheWriteTokens,
+    totalInputTokens:
+      input.usage.inputTokens +
+      input.usage.cacheReadTokens +
+      input.usage.cacheWriteTokens,
+    outputTokens: input.usage.outputTokens,
+  });
+};
+
 type BunFetchRequestInit = RequestInit & {
   timeout?: number | false;
 };
@@ -232,6 +373,23 @@ const proxyRequest = async (
             codexSessionId
           )
         : null;
+      const codexSessionSource = readCodexSessionSource(
+        requestBodyJson,
+        headers
+      );
+      const codexSessionHash = codexUpstreamSessionId
+        ? codexUpstreamSessionId.replace(/^kleis_/, "").slice(0, 16)
+        : null;
+      const codexIncomingHeaders = new Headers(headers);
+      const onCodexTokenUsage = (tokenUsage: TokenUsage): void => {
+        usageRecorder.onTokenUsage(tokenUsage);
+        logCodexUsageDiagnostic({
+          model: usageModel,
+          sessionHash: codexSessionHash,
+          sessionSource: codexSessionSource,
+          usage: tokenUsage,
+        });
+      };
       const codexProxy = prepareCodexProxyRequest({
         headers,
         accessToken: account.accessToken,
@@ -241,11 +399,17 @@ const proxyRequest = async (
         bodyText: requestBody,
         bodyJson: requestBodyJson,
         sessionId: codexUpstreamSessionId,
-        onTokenUsage: usageRecorder.onTokenUsage,
+        onTokenUsage: onCodexTokenUsage,
       });
       upstreamUrl = codexProxy.upstreamUrl;
       requestBody = codexProxy.bodyText;
       responseTransformer = codexProxy.transformResponse;
+      logCodexRequestDiagnostic({
+        body: codexProxy.bodyJson,
+        headers: codexIncomingHeaders,
+        sessionHash: codexSessionHash,
+        sessionSource: codexSessionSource,
+      });
 
       const webSocketResponse = await tryProxyCodexWebSocket({
         headers,
@@ -253,7 +417,7 @@ const proxyRequest = async (
         accountKey: `${apiKeyId}:${account.id}`,
         sessionId: codexSessionId,
         upstreamSessionId: codexUpstreamSessionId,
-        onTokenUsage: usageRecorder.onTokenUsage,
+        onTokenUsage: onCodexTokenUsage,
         signal: context.req.raw.signal,
       });
       if (webSocketResponse) {

--- a/src/providers/codex.ts
+++ b/src/providers/codex.ts
@@ -35,6 +35,7 @@ const CODEX_DEVICE_USER_CODE_URL = `${CODEX_ISSUER}/api/accounts/deviceauth/user
 const CODEX_DEVICE_TOKEN_URL = `${CODEX_ISSUER}/api/accounts/deviceauth/token`;
 const CODEX_OAUTH_STATE_TTL_MS = 15 * 60 * 1000;
 const CODEX_POLLING_SAFETY_MARGIN_MS = 3000;
+const CODEX_SLOW_DOWN_INCREMENT_MS = 5000;
 
 const codexStartOptionsSchema = z.object({
   mode: z.enum(["browser", "headless"]).optional(),
@@ -82,6 +83,10 @@ type CodexDeviceAuthorizationResponse = {
 type CodexDeviceTokenResponse = {
   authorization_code?: string;
   code_verifier?: string;
+};
+
+type CodexDeviceTokenErrorResponse = {
+  error?: string | { code?: string };
 };
 
 const resolveCodexOAuthMode = (
@@ -172,6 +177,33 @@ const parseTokenResponse = async (
   return body;
 };
 
+const readCodexDeviceTokenErrorCode = async (
+  response: Response
+): Promise<string | null> => {
+  const text = await response
+    .clone()
+    .text()
+    .catch(() => "");
+  if (!text) {
+    return null;
+  }
+
+  try {
+    const body = JSON.parse(text) as CodexDeviceTokenErrorResponse;
+    const error = body.error;
+    if (typeof error === "string") {
+      return error;
+    }
+    return typeof error?.code === "string" ? error.code : null;
+  } catch {
+    return null;
+  }
+};
+
+const waitForCodexDevicePoll = async (intervalMs: number): Promise<void> => {
+  await sleep(intervalMs + CODEX_POLLING_SAFETY_MARGIN_MS);
+};
+
 const exchangeAuthorizationCodeForTokens = async (input: {
   code: string;
   redirectUri: string;
@@ -238,6 +270,7 @@ const pollDeviceAuthorizationCode = async (input: {
   intervalMs: number;
   expiresAt: number;
 }): Promise<{ authorizationCode: string; codeVerifier: string }> => {
+  let intervalMs = input.intervalMs;
   while (Date.now() < input.expiresAt) {
     const response = await fetch(CODEX_DEVICE_TOKEN_URL, {
       method: "POST",
@@ -263,7 +296,18 @@ const pollDeviceAuthorizationCode = async (input: {
     }
 
     if (response.status === 403 || response.status === 404) {
-      await sleep(input.intervalMs + CODEX_POLLING_SAFETY_MARGIN_MS);
+      await waitForCodexDevicePoll(intervalMs);
+      continue;
+    }
+
+    const errorCode = await readCodexDeviceTokenErrorCode(response);
+    if (errorCode === "deviceauth_authorization_pending") {
+      await waitForCodexDevicePoll(intervalMs);
+      continue;
+    }
+    if (errorCode === "slow_down") {
+      intervalMs += CODEX_SLOW_DOWN_INCREMENT_MS;
+      await waitForCodexDevicePoll(intervalMs);
       continue;
     }
 

--- a/src/providers/codex.ts
+++ b/src/providers/codex.ts
@@ -295,18 +295,17 @@ const pollDeviceAuthorizationCode = async (input: {
       };
     }
 
-    if (response.status === 403 || response.status === 404) {
-      await waitForCodexDevicePoll(intervalMs);
-      continue;
-    }
-
     const errorCode = await readCodexDeviceTokenErrorCode(response);
-    if (errorCode === "deviceauth_authorization_pending") {
-      await waitForCodexDevicePoll(intervalMs);
-      continue;
-    }
     if (errorCode === "slow_down") {
       intervalMs += CODEX_SLOW_DOWN_INCREMENT_MS;
+      await waitForCodexDevicePoll(intervalMs);
+      continue;
+    }
+    if (
+      errorCode === "deviceauth_authorization_pending" ||
+      response.status === 403 ||
+      response.status === 404
+    ) {
       await waitForCodexDevicePoll(intervalMs);
       continue;
     }

--- a/src/providers/codex.ts
+++ b/src/providers/codex.ts
@@ -200,8 +200,17 @@ const readCodexDeviceTokenErrorCode = async (
   }
 };
 
-const waitForCodexDevicePoll = async (intervalMs: number): Promise<void> => {
-  await sleep(intervalMs + CODEX_POLLING_SAFETY_MARGIN_MS);
+const waitForCodexDevicePoll = async (input: {
+  intervalMs: number;
+  expiresAt: number;
+}): Promise<void> => {
+  const remainingMs = input.expiresAt - Date.now();
+  if (remainingMs <= 0) {
+    return;
+  }
+  await sleep(
+    Math.min(input.intervalMs + CODEX_POLLING_SAFETY_MARGIN_MS, remainingMs)
+  );
 };
 
 const exchangeAuthorizationCodeForTokens = async (input: {
@@ -298,15 +307,14 @@ const pollDeviceAuthorizationCode = async (input: {
     const errorCode = await readCodexDeviceTokenErrorCode(response);
     if (errorCode === "slow_down") {
       intervalMs += CODEX_SLOW_DOWN_INCREMENT_MS;
-      await waitForCodexDevicePoll(intervalMs);
-      continue;
     }
     if (
+      errorCode === "slow_down" ||
       errorCode === "deviceauth_authorization_pending" ||
       response.status === 403 ||
       response.status === 404
     ) {
-      await waitForCodexDevicePoll(intervalMs);
+      await waitForCodexDevicePoll({ intervalMs, expiresAt: input.expiresAt });
       continue;
     }
 

--- a/src/providers/constants.ts
+++ b/src/providers/constants.ts
@@ -6,6 +6,7 @@ export const CODEX_RESPONSE_ENDPOINT =
 export const CODEX_WEBSOCKET_BETA_HEADER = "responses_websockets=2026-02-06";
 // https://github.com/anomalyco/opencode/blob/d848c9b6a32f408e8b9bf6448b83af05629454d0/packages/opencode/src/plugin/codex.ts#L619
 export const CODEX_ORIGINATOR = "opencode";
+export const CODEX_USER_AGENT = "opencode";
 
 // https://github.com/anomalyco/opencode/blob/d848c9b6a32f408e8b9bf6448b83af05629454d0/packages/opencode/src/plugin/copilot.ts#L121-L131
 // https://github.com/badlogic/pi-mono/blob/5c0ec26c28c918c5301f218e8c13fcc540d8e3a4/packages/ai/src/providers/github-copilot-headers.ts#L27-L34

--- a/src/providers/proxies/codex-proxy.ts
+++ b/src/providers/proxies/codex-proxy.ts
@@ -16,6 +16,7 @@ import {
   CODEX_ACCOUNT_ID_HEADER,
   CODEX_ORIGINATOR,
   CODEX_RESPONSE_ENDPOINT,
+  CODEX_USER_AGENT,
 } from "../constants";
 
 const trimString = (value: unknown): string =>
@@ -78,7 +79,8 @@ export const transformCodexBodyJson = (
   //   https://github.com/anomalyco/opencode/blob/d848c9b6a32f408e8b9bf6448b83af05629454d0/packages/opencode/src/session/llm.ts#L65-L112
   // - Codex-native clients include `instructions` explicitly in the request body.
   //   https://github.com/badlogic/pi-mono/blob/5c0ec26c28c918c5301f218e8c13fcc540d8e3a4/packages/ai/src/providers/openai-codex-responses.ts#L286-L291
-  // - Codex-native clients also omit `max_output_tokens` / `max_completion_tokens`.
+  // - Codex-native clients also omit `max_output_tokens` / `max_completion_tokens`
+  //   and force `store: false`.
   //   https://github.com/badlogic/pi-mono/blob/5c0ec26c28c918c5301f218e8c13fcc540d8e3a4/packages/ai/src/providers/openai-codex-responses.ts#L286-L315
   const {
     max_output_tokens: _maxOutputTokens,
@@ -96,6 +98,7 @@ export const transformCodexBodyJson = (
   return {
     ...nextBody,
     instructions,
+    store: false,
     ...(sessionId ? { prompt_cache_key: sessionId } : {}),
   };
 };
@@ -139,6 +142,11 @@ export const prepareCodexProxyRequest = (
   const bodyJson = transformCodexBodyJson(input.bodyJson, input.sessionId);
 
   input.headers.set("authorization", `Bearer ${input.accessToken}`);
+  input.headers.set("content-type", "application/json");
+  input.headers.set("User-Agent", CODEX_USER_AGENT);
+  if (isStreamingRequest) {
+    input.headers.set("accept", "text/event-stream");
+  }
   if (!input.headers.get("originator")) {
     input.headers.set("originator", CODEX_ORIGINATOR);
   }

--- a/src/providers/proxies/codex-websocket.ts
+++ b/src/providers/proxies/codex-websocket.ts
@@ -88,12 +88,6 @@ const fallbackSocketKeys = new Map<string, ReturnType<typeof setTimeout>>();
 const streamFailureCounts = new Map<string, number>();
 const pendingSocketKeys = new Set<string>();
 const suppressContinuationStoreKeys = new Set<string>();
-let diagnosticRequestCounter = 0;
-
-const nextDiagnosticRequestId = (): string => {
-  diagnosticRequestCounter = (diagnosticRequestCounter + 1) % 1_000_000;
-  return `${Date.now().toString(36)}-${diagnosticRequestCounter.toString(36)}`;
-};
 
 const resolveCodexWebSocketUrl = (): string => {
   const url = new URL(CODEX_RESPONSE_ENDPOINT);
@@ -768,133 +762,6 @@ const isCacheableFinalEvent = (
   (eventType === "response.completed" || eventType === "response.done") &&
   (!responseStatus || responseStatus === "completed");
 
-const sessionHash = (sessionId: string | null | undefined): string | null =>
-  sessionId ? sessionId.replace(/^kleis_/, "").slice(0, 16) : null;
-
-const logCodexWebSocketDiagnostic = (
-  payload: Record<string, unknown>
-): void => {
-  process.stderr.write(`${JSON.stringify(payload)}\n`);
-};
-
-const errorShape = (error: unknown): Record<string, unknown> => ({
-  name: error instanceof Error ? error.name : typeof error,
-  message: error instanceof Error ? error.message : String(error),
-});
-
-const closeEventShape = (event: unknown): Record<string, unknown> | null => {
-  if (!isObjectRecord(event)) {
-    return null;
-  }
-  return {
-    code: typeof event.code === "number" ? event.code : null,
-    wasClean: typeof event.wasClean === "boolean" ? event.wasClean : null,
-  };
-};
-
-const logCodexWebSocketLifecycle = (input: {
-  diagnosticRequestId: string;
-  model: unknown;
-  upstreamSessionId: string | null;
-  stage: string;
-  elapsedMs: number;
-  cacheDecision?: string;
-  error?: unknown;
-  closeEvent?: unknown;
-  messagesReceived?: number;
-  queueLength?: number;
-  terminal?: boolean;
-  settled?: boolean;
-  failureSet?: boolean;
-  sentInputItems?: number | null;
-  hasPreviousResponseId?: boolean;
-  retryAttempt?: number;
-  streamFailures?: number;
-  fallbackActive?: boolean;
-}): void => {
-  logCodexWebSocketDiagnostic({
-    event: "codex_compaction_ws_lifecycle",
-    diagnosticRequestId: input.diagnosticRequestId,
-    model: readString(input.model),
-    sessionHash: sessionHash(input.upstreamSessionId),
-    stage: input.stage,
-    elapsedMs: input.elapsedMs,
-    cacheDecision: input.cacheDecision,
-    ...(input.error ? { error: errorShape(input.error) } : {}),
-    ...(input.closeEvent
-      ? { closeEvent: closeEventShape(input.closeEvent) }
-      : {}),
-    messagesReceived: input.messagesReceived,
-    queueLength: input.queueLength,
-    terminal: input.terminal,
-    settled: input.settled,
-    failureSet: input.failureSet,
-    sentInputItems: input.sentInputItems,
-    hasPreviousResponseId: input.hasPreviousResponseId,
-    retryAttempt: input.retryAttempt,
-    streamFailures: input.streamFailures,
-    fallbackActive: input.fallbackActive,
-  });
-};
-
-const logCodexWebSocketDecision = (input: {
-  diagnosticRequestId: string;
-  model: unknown;
-  upstreamSessionId: string | null;
-  decision: CacheDecision;
-  requestBody: Record<string, unknown>;
-  firstEventType: unknown;
-}): void => {
-  logCodexWebSocketDiagnostic({
-    event: "codex_compaction_ws_decision",
-    diagnosticRequestId: input.diagnosticRequestId,
-    model: readString(input.model),
-    sessionHash: sessionHash(input.upstreamSessionId),
-    cacheDecision: input.decision.reason,
-    cachedDelta:
-      input.decision.reason === "delta" ||
-      input.decision.reason === "normalized_delta",
-    currentInputItems: input.decision.currentInputItems,
-    cachedInputItems: input.decision.cachedInputItems,
-    cachedResponseItems: input.decision.cachedResponseItems,
-    baselineItems: input.decision.baselineItems,
-    deltaItems: input.decision.deltaItems,
-    sentInputItems: inputItems(input.requestBody),
-    hasPreviousResponseId:
-      typeof input.requestBody.previous_response_id === "string",
-    firstEventType: readString(input.firstEventType),
-  });
-};
-
-const logCodexWebSocketStore = (input: {
-  diagnosticRequestId: string;
-  model: unknown;
-  upstreamSessionId: string | null;
-  elapsedMs: number;
-  keptSocket: boolean;
-  responseIdPresent: boolean;
-  responseItems: number;
-  storedContinuation: boolean;
-  finalEventType: unknown;
-  finalResponseStatus: string | null;
-  skippedStore: boolean;
-}): void => {
-  logCodexWebSocketDiagnostic({
-    event: "codex_compaction_ws_store",
-    diagnosticRequestId: input.diagnosticRequestId,
-    model: readString(input.model),
-    sessionHash: sessionHash(input.upstreamSessionId),
-    elapsedMs: input.elapsedMs,
-    keptSocket: input.keptSocket,
-    responseIdPresent: input.responseIdPresent,
-    responseItems: input.responseItems,
-    storedContinuation: input.storedContinuation,
-    finalEventType: readString(input.finalEventType),
-    finalResponseStatus: input.finalResponseStatus,
-    skippedStore: input.skippedStore,
-  });
-};
-
 const buildWebSocketHeaders = (
   headers: Headers,
   requestId: string
@@ -911,8 +778,6 @@ const buildWebSocketHeaders = (
 export const tryProxyCodexWebSocket = async (
   input: CodexWebSocketInput
 ): Promise<Response | null> => {
-  const diagnosticRequestId = nextDiagnosticRequestId();
-  const startedAt = Date.now();
   const body = input.bodyJson;
   if (
     !body ||
@@ -932,15 +797,6 @@ export const tryProxyCodexWebSocket = async (
   const headers = buildWebSocketHeaders(input.headers, requestId);
 
   if (cacheKey && fallbackSocketKeys.has(cacheKey)) {
-    logCodexWebSocketLifecycle({
-      diagnosticRequestId,
-      model: body.model,
-      upstreamSessionId: input.upstreamSessionId ?? null,
-      stage: "session_fallback_active",
-      elapsedMs: Date.now() - startedAt,
-      streamFailures: streamFailureCounts.get(cacheKey) ?? 0,
-      fallbackActive: true,
-    });
     return null;
   }
 
@@ -949,31 +805,15 @@ export const tryProxyCodexWebSocket = async (
     sessionId ? { ...body, prompt_cache_key: requestId } : body
   );
   let requestBody: Record<string, unknown>;
-  let cacheDecision: CacheDecision;
   try {
     acquired = await acquireSocket(headers, cacheKey, input.signal);
     const builtRequest = buildRequestBody(fullBody, acquired.cached);
     requestBody = builtRequest.body;
-    cacheDecision = builtRequest.decision;
   } catch (error) {
     acquired?.release(false);
-    let streamFailures: number | undefined;
     if (!input.signal?.aborted && !isSessionConcurrencyError(error)) {
-      streamFailures = recordSessionStreamFailure(cacheKey);
+      recordSessionStreamFailure(cacheKey);
     }
-    const fallbackActive = cacheKey
-      ? fallbackSocketKeys.has(cacheKey)
-      : undefined;
-    logCodexWebSocketLifecycle({
-      diagnosticRequestId,
-      model: body.model,
-      upstreamSessionId: input.upstreamSessionId ?? null,
-      stage: "acquire_failed",
-      elapsedMs: Date.now() - startedAt,
-      error,
-      ...(streamFailures === undefined ? {} : { streamFailures }),
-      ...(fallbackActive === undefined ? {} : { fallbackActive }),
-    });
     return null;
   }
 
@@ -987,7 +827,6 @@ export const tryProxyCodexWebSocket = async (
   let settled = false;
   let terminal = false;
   let failure: unknown = null;
-  let messagesReceived = 0;
   let emittedPayload = false;
   let connectionLimitAttempts = 0;
   let retryingConnectionLimit = false;
@@ -1077,23 +916,6 @@ export const tryProxyCodexWebSocket = async (
     active.socket.removeEventListener("error", onError);
     active.socket.removeEventListener("close", onClose);
     closeSocket(active.socket);
-    logCodexWebSocketLifecycle({
-      diagnosticRequestId,
-      model: requestBody.model,
-      upstreamSessionId: input.upstreamSessionId ?? null,
-      stage: "connection_limit_retry",
-      elapsedMs: Date.now() - startedAt,
-      cacheDecision: cacheDecision.reason,
-      retryAttempt: connectionLimitAttempts,
-      messagesReceived,
-      queueLength: queue.length,
-      terminal,
-      settled,
-      failureSet: Boolean(failure),
-      sentInputItems: inputItems(requestBody),
-      hasPreviousResponseId:
-        typeof requestBody.previous_response_id === "string",
-    });
 
     try {
       const nextSocket = await connectWebSocket(headers, input.signal);
@@ -1111,7 +933,7 @@ export const tryProxyCodexWebSocket = async (
     }
   };
 
-  const fail = (stage: string, error: unknown, closeEvent?: unknown): void => {
+  const fail = (stage: string, error: unknown): void => {
     if (settled) {
       return;
     }
@@ -1120,32 +942,9 @@ export const tryProxyCodexWebSocket = async (
     failure = error;
     cleanup();
     active.release(false);
-    const streamFailures = isUserCancelledStage(stage)
-      ? undefined
-      : recordSessionStreamFailure(cacheKey);
-    const fallbackActive = cacheKey
-      ? fallbackSocketKeys.has(cacheKey)
-      : undefined;
-    logCodexWebSocketLifecycle({
-      diagnosticRequestId,
-      model: requestBody.model,
-      upstreamSessionId: input.upstreamSessionId ?? null,
-      stage,
-      elapsedMs: Date.now() - startedAt,
-      cacheDecision: cacheDecision.reason,
-      error,
-      closeEvent,
-      messagesReceived,
-      queueLength: queue.length,
-      terminal,
-      settled,
-      failureSet: true,
-      sentInputItems: inputItems(requestBody),
-      hasPreviousResponseId:
-        typeof requestBody.previous_response_id === "string",
-      ...(streamFailures === undefined ? {} : { streamFailures }),
-      ...(fallbackActive === undefined ? {} : { fallbackActive }),
-    });
+    if (!isUserCancelledStage(stage)) {
+      recordSessionStreamFailure(cacheKey);
+    }
     firstPayloadReject?.(error);
     wakePull();
   };
@@ -1156,7 +955,6 @@ export const tryProxyCodexWebSocket = async (
     }
     settled = true;
     cleanup();
-    const skippedStore = active.cached?.skipNextContinuationStore ?? false;
     const canStoreContinuation = Boolean(
       active.cached &&
         keepSocket &&
@@ -1179,19 +977,6 @@ export const tryProxyCodexWebSocket = async (
     if (isCacheableFinalEvent(finalEventType, finalResponseStatus)) {
       clearSessionStreamFailures(cacheKey);
     }
-    logCodexWebSocketStore({
-      diagnosticRequestId,
-      model: requestBody.model,
-      upstreamSessionId: input.upstreamSessionId ?? null,
-      elapsedMs: Date.now() - startedAt,
-      keptSocket: keepSocket,
-      responseIdPresent: Boolean(responseId),
-      responseItems: responseItems.length,
-      storedContinuation: canStoreContinuation,
-      finalEventType,
-      finalResponseStatus,
-      skippedStore,
-    });
     active.release(keepSocket);
     wakePull();
   };
@@ -1204,31 +989,10 @@ export const tryProxyCodexWebSocket = async (
 
   const onClose = (event: unknown): void => {
     if (terminal) {
-      logCodexWebSocketLifecycle({
-        diagnosticRequestId,
-        model: requestBody.model,
-        upstreamSessionId: input.upstreamSessionId ?? null,
-        stage: "socket_closed_after_terminal",
-        elapsedMs: Date.now() - startedAt,
-        cacheDecision: cacheDecision.reason,
-        closeEvent: event,
-        messagesReceived,
-        queueLength: queue.length,
-        terminal,
-        settled,
-        failureSet: Boolean(failure),
-        sentInputItems: inputItems(requestBody),
-        hasPreviousResponseId:
-          typeof requestBody.previous_response_id === "string",
-      });
       wakePull();
       return;
     }
-    fail(
-      "socket_closed_before_terminal",
-      extractWebSocketCloseError(event),
-      event
-    );
+    fail("socket_closed_before_terminal", extractWebSocketCloseError(event));
   };
 
   const handleMessage = async (event: unknown): Promise<void> => {
@@ -1246,7 +1010,6 @@ export const tryProxyCodexWebSocket = async (
     if (!isObjectRecord(payload)) {
       return;
     }
-    messagesReceived++;
     resetResponseIdleTimer("idle_timeout_waiting_for_websocket");
 
     if (!emittedPayload && isConnectionLimitPayload(payload)) {
@@ -1263,22 +1026,6 @@ export const tryProxyCodexWebSocket = async (
       finalResponseStatus = isObjectRecord(payload.response)
         ? readString(payload.response.status)
         : null;
-      logCodexWebSocketLifecycle({
-        diagnosticRequestId,
-        model: requestBody.model,
-        upstreamSessionId: input.upstreamSessionId ?? null,
-        stage: "upstream_terminal_received",
-        elapsedMs: Date.now() - startedAt,
-        cacheDecision: cacheDecision.reason,
-        messagesReceived,
-        queueLength: queue.length,
-        terminal,
-        settled,
-        failureSet: Boolean(failure),
-        sentInputItems: inputItems(requestBody),
-        hasPreviousResponseId:
-          typeof requestBody.previous_response_id === "string",
-      });
     }
     emittedPayload = true;
     queue.push(payload);
@@ -1304,39 +1051,9 @@ export const tryProxyCodexWebSocket = async (
   let first: Record<string, unknown>;
   try {
     first = await firstPayload;
-  } catch (error) {
-    logCodexWebSocketLifecycle({
-      diagnosticRequestId,
-      model: requestBody.model,
-      upstreamSessionId: input.upstreamSessionId ?? null,
-      stage: "first_payload_failed",
-      elapsedMs: Date.now() - startedAt,
-      cacheDecision: cacheDecision.reason,
-      error,
-      messagesReceived,
-      queueLength: queue.length,
-      terminal,
-      settled,
-      failureSet: Boolean(failure),
-      sentInputItems: inputItems(requestBody),
-      hasPreviousResponseId:
-        typeof requestBody.previous_response_id === "string",
-      ...(cacheKey && streamFailureCounts.has(cacheKey)
-        ? { streamFailures: streamFailureCounts.get(cacheKey) ?? 0 }
-        : {}),
-      ...(cacheKey ? { fallbackActive: fallbackSocketKeys.has(cacheKey) } : {}),
-    });
+  } catch {
     return null;
   }
-
-  logCodexWebSocketDecision({
-    diagnosticRequestId,
-    model: requestBody.model,
-    upstreamSessionId: input.upstreamSessionId ?? null,
-    decision: cacheDecision,
-    requestBody,
-    firstEventType: first.type,
-  });
 
   if (isErrorPayload(first)) {
     keepSocket = false;
@@ -1407,22 +1124,6 @@ export const tryProxyCodexWebSocket = async (
     },
     cancel(): void {
       if (settled) {
-        logCodexWebSocketLifecycle({
-          diagnosticRequestId,
-          model: requestBody.model,
-          upstreamSessionId: input.upstreamSessionId ?? null,
-          stage: "downstream_cancel_after_settled",
-          elapsedMs: Date.now() - startedAt,
-          cacheDecision: cacheDecision.reason,
-          messagesReceived,
-          queueLength: queue.length,
-          terminal,
-          settled,
-          failureSet: Boolean(failure),
-          sentInputItems: inputItems(requestBody),
-          hasPreviousResponseId:
-            typeof requestBody.previous_response_id === "string",
-        });
         return;
       }
       fail("downstream_cancel", new Error("Response stream was cancelled"));

--- a/src/providers/proxies/codex-websocket.ts
+++ b/src/providers/proxies/codex-websocket.ts
@@ -210,6 +210,7 @@ const markSessionFallback = (key: string | null): void => {
   clearSessionFallback(key);
   const timer = setTimeout(() => {
     fallbackSocketKeys.delete(key);
+    streamFailureCounts.delete(key);
   }, SESSION_SOCKET_TTL_MS);
   fallbackSocketKeys.set(key, timer);
 };
@@ -741,6 +742,12 @@ const readPayloadStatus = (payload: Record<string, unknown>): number => {
 const isErrorPayload = (payload: Record<string, unknown>): boolean =>
   payload.type === "error" || payload.type === "response.failed";
 
+const isTerminalPayload = (payload: Record<string, unknown>): boolean =>
+  payload.type === "response.completed" ||
+  payload.type === "response.done" ||
+  payload.type === "response.incomplete" ||
+  isErrorPayload(payload);
+
 const isConnectionLimitPayload = (payload: Record<string, unknown>): boolean =>
   payload.type === "error" &&
   isObjectRecord(payload.error) &&
@@ -951,7 +958,7 @@ export const tryProxyCodexWebSocket = async (
   } catch (error) {
     acquired?.release(false);
     let streamFailures: number | undefined;
-    if (!isSessionConcurrencyError(error)) {
+    if (!input.signal?.aborted && !isSessionConcurrencyError(error)) {
       streamFailures = recordSessionStreamFailure(cacheKey);
     }
     const fallbackActive = cacheKey
@@ -983,7 +990,9 @@ export const tryProxyCodexWebSocket = async (
   let messagesReceived = 0;
   let emittedPayload = false;
   let connectionLimitAttempts = 0;
+  let retryingConnectionLimit = false;
   let responseIdleTimer: ReturnType<typeof setTimeout> | null = null;
+  let messageChain = Promise.resolve();
   let wake: (() => void) | null = null;
   const queue: Record<string, unknown>[] = [];
 
@@ -1040,7 +1049,6 @@ export const tryProxyCodexWebSocket = async (
 
   const sendRequest = (): void => {
     try {
-      resetResponseIdleTimer("idle_timeout_sending_websocket_request");
       active.socket.send(
         JSON.stringify({ ...requestBody, type: "response.create" })
       );
@@ -1051,7 +1059,7 @@ export const tryProxyCodexWebSocket = async (
   };
 
   const retryConnectionLimit = async (): Promise<void> => {
-    if (settled) {
+    if (settled || retryingConnectionLimit) {
       return;
     }
     if (connectionLimitAttempts >= CONNECTION_LIMIT_RETRIES) {
@@ -1063,6 +1071,7 @@ export const tryProxyCodexWebSocket = async (
     }
 
     connectionLimitAttempts++;
+    retryingConnectionLimit = true;
     clearResponseIdleTimer();
     active.socket.removeEventListener("message", onMessage);
     active.socket.removeEventListener("error", onError);
@@ -1097,6 +1106,8 @@ export const tryProxyCodexWebSocket = async (
       sendRequest();
     } catch (error) {
       fail("connection_limit_retry_failed", error);
+    } finally {
+      retryingConnectionLimit = false;
     }
   };
 
@@ -1146,7 +1157,7 @@ export const tryProxyCodexWebSocket = async (
     settled = true;
     cleanup();
     const skippedStore = active.cached?.skipNextContinuationStore ?? false;
-    const storedContinuation = Boolean(
+    const canStoreContinuation = Boolean(
       active.cached &&
         keepSocket &&
         responseId &&
@@ -1154,12 +1165,7 @@ export const tryProxyCodexWebSocket = async (
         !active.cached.skipNextContinuationStore
     );
     if (active.cached) {
-      if (
-        keepSocket &&
-        responseId &&
-        isCacheableFinalEvent(finalEventType, finalResponseStatus) &&
-        !active.cached.skipNextContinuationStore
-      ) {
+      if (canStoreContinuation && responseId) {
         active.cached.continuation = {
           lastRequestBody: fullBody,
           lastResponseId: responseId,
@@ -1181,7 +1187,7 @@ export const tryProxyCodexWebSocket = async (
       keptSocket: keepSocket,
       responseIdPresent: Boolean(responseId),
       responseItems: responseItems.length,
-      storedContinuation,
+      storedContinuation: canStoreContinuation,
       finalEventType,
       finalResponseStatus,
       skippedStore,
@@ -1226,10 +1232,13 @@ export const tryProxyCodexWebSocket = async (
   };
 
   const handleMessage = async (event: unknown): Promise<void> => {
+    if (settled) {
+      return;
+    }
     const text = await decodeMessageData(
       isObjectRecord(event) ? event.data : null
     );
-    if (!text) {
+    if (settled || !text) {
       return;
     }
 
@@ -1247,12 +1256,8 @@ export const tryProxyCodexWebSocket = async (
       return;
     }
 
-    if (
-      payload.type === "response.completed" ||
-      payload.type === "response.done" ||
-      payload.type === "response.incomplete" ||
-      isErrorPayload(payload)
-    ) {
+    if (isTerminalPayload(payload)) {
+      clearResponseIdleTimer();
       terminal = true;
       finalEventType = payload.type;
       finalResponseStatus = isObjectRecord(payload.response)
@@ -1284,9 +1289,11 @@ export const tryProxyCodexWebSocket = async (
   };
 
   const onMessage = (event: unknown): void => {
-    handleMessage(event).catch((error: unknown) => {
-      fail("message_parse_failed", error);
-    });
+    messageChain = messageChain
+      .then(() => handleMessage(event))
+      .catch((error: unknown) => {
+        fail("message_parse_failed", error);
+      });
   };
 
   attachSocketListeners();
@@ -1354,22 +1361,13 @@ export const tryProxyCodexWebSocket = async (
     }
 
     controller.enqueue(encodeSse(payload));
-    if (
-      payload.type === "response.completed" ||
-      payload.type === "response.done" ||
-      payload.type === "response.incomplete"
-    ) {
+    if (isTerminalPayload(payload)) {
       if (payload.type === "response.incomplete") {
         keepSocket = false;
       }
-      terminal = true;
-      finalEventType = payload.type;
-      finalResponseStatus = isObjectRecord(payload.response)
-        ? readString(payload.response.status)
-        : null;
-      finish();
-    } else if (isErrorPayload(payload)) {
-      keepSocket = false;
+      if (isErrorPayload(payload)) {
+        keepSocket = false;
+      }
       terminal = true;
       finalEventType = payload.type;
       finalResponseStatus = isObjectRecord(payload.response)

--- a/src/providers/proxies/codex-websocket.ts
+++ b/src/providers/proxies/codex-websocket.ts
@@ -13,6 +13,10 @@ import { isObjectRecord, readBooleanField } from "../../utils/object";
 
 const SESSION_SOCKET_TTL_MS = 5 * 60 * 1000;
 const CONNECT_TIMEOUT_MS = 15_000;
+const RESPONSE_IDLE_TIMEOUT_MS = 5 * 60 * 1000;
+const MAX_SOCKET_AGE_MS = 55 * 60 * 1000;
+const CONNECTION_LIMIT_RETRIES = 5;
+const CONNECTION_LIMIT_REACHED_CODE = "websocket_connection_limit_reached";
 
 type WebSocketEventType = "open" | "message" | "error" | "close";
 type WebSocketListener = (event: unknown) => void;
@@ -51,6 +55,7 @@ type ContinuationState = {
 
 type CachedSocket = {
   socket: WebSocketLike;
+  connectedAt: number;
   busy: boolean;
   idleTimer: ReturnType<typeof setTimeout> | null;
   continuation: ContinuationState | null;
@@ -77,6 +82,7 @@ type CacheDecision = {
 };
 
 const socketCache = new Map<string, CachedSocket>();
+const fallbackSocketKeys = new Map<string, ReturnType<typeof setTimeout>>();
 const pendingSocketKeys = new Set<string>();
 const suppressContinuationStoreKeys = new Set<string>();
 let diagnosticRequestCounter = 0;
@@ -137,12 +143,34 @@ const emptyCacheDecision = (
 const isSocketOpen = (socket: WebSocketLike): boolean =>
   socket.readyState === undefined || socket.readyState === 1;
 
+const isSocketFresh = (cached: CachedSocket): boolean =>
+  Date.now() - cached.connectedAt < MAX_SOCKET_AGE_MS;
+
 const closeSocket = (socket: WebSocketLike): void => {
   try {
     socket.close(1000, "done");
   } catch {
     // Ignore close failures from already-closed sockets.
   }
+};
+
+const clearSessionFallback = (key: string): void => {
+  const timer = fallbackSocketKeys.get(key);
+  if (timer) {
+    clearTimeout(timer);
+    fallbackSocketKeys.delete(key);
+  }
+};
+
+const markSessionFallback = (key: string | null): void => {
+  if (!key) {
+    return;
+  }
+  clearSessionFallback(key);
+  const timer = setTimeout(() => {
+    fallbackSocketKeys.delete(key);
+  }, SESSION_SOCKET_TTL_MS);
+  fallbackSocketKeys.set(key, timer);
 };
 
 const scheduleExpiry = (key: string, cached: CachedSocket): void => {
@@ -157,6 +185,7 @@ const scheduleExpiry = (key: string, cached: CachedSocket): void => {
 
     closeSocket(cached.socket);
     socketCache.delete(key);
+    clearSessionFallback(key);
   }, SESSION_SOCKET_TTL_MS);
 };
 
@@ -249,11 +278,12 @@ const acquireSocket = async (
 }> => {
   if (!cacheKey) {
     const socket = await connectWebSocket(headers, signal);
-    return {
+    const acquired = {
       socket,
       cached: null,
-      release: () => closeSocket(socket),
+      release: (): void => closeSocket(acquired.socket),
     };
+    return acquired;
   }
 
   const existing = socketCache.get(cacheKey);
@@ -269,7 +299,7 @@ const acquireSocket = async (
       existing.idleTimer = null;
     }
 
-    if (isSocketOpen(existing.socket)) {
+    if (isSocketOpen(existing.socket) && isSocketFresh(existing)) {
       existing.busy = true;
       return {
         socket: existing.socket,
@@ -307,6 +337,7 @@ const acquireSocket = async (
   }
   const cached: CachedSocket = {
     socket,
+    connectedAt: Date.now(),
     busy: true,
     idleTimer: null,
     continuation: null,
@@ -317,8 +348,8 @@ const acquireSocket = async (
     socket,
     cached,
     release(keep: boolean): void {
-      if (!(keep && isSocketOpen(socket))) {
-        closeSocket(socket);
+      if (!(keep && isSocketOpen(cached.socket))) {
+        closeSocket(cached.socket);
         socketCache.delete(cacheKey);
         return;
       }
@@ -336,6 +367,10 @@ export const closeCodexWebSocketSessions = (): void => {
     closeSocket(cached.socket);
   }
   socketCache.clear();
+  for (const timer of fallbackSocketKeys.values()) {
+    clearTimeout(timer);
+  }
+  fallbackSocketKeys.clear();
 };
 
 const withoutContinuationFields = (
@@ -630,6 +665,16 @@ const readPayloadStatus = (payload: Record<string, unknown>): number => {
 const isErrorPayload = (payload: Record<string, unknown>): boolean =>
   payload.type === "error" || payload.type === "response.failed";
 
+const isConnectionLimitPayload = (payload: Record<string, unknown>): boolean =>
+  payload.type === "error" &&
+  isObjectRecord(payload.error) &&
+  payload.error.code === CONNECTION_LIMIT_REACHED_CODE;
+
+const isSessionConcurrencyError = (error: unknown): boolean =>
+  error instanceof Error &&
+  (error.message === "Codex WebSocket session is busy" ||
+    error.message === "Codex WebSocket session is connecting");
+
 const isCacheableFinalEvent = (
   eventType: unknown,
   responseStatus: string | null
@@ -677,6 +722,7 @@ const logCodexWebSocketLifecycle = (input: {
   failureSet?: boolean;
   sentInputItems?: number | null;
   hasPreviousResponseId?: boolean;
+  retryAttempt?: number;
 }): void => {
   logCodexWebSocketDiagnostic({
     event: "codex_compaction_ws_lifecycle",
@@ -697,6 +743,7 @@ const logCodexWebSocketLifecycle = (input: {
     failureSet: input.failureSet,
     sentInputItems: input.sentInputItems,
     hasPreviousResponseId: input.hasPreviousResponseId,
+    retryAttempt: input.retryAttempt,
   });
 };
 
@@ -794,6 +841,17 @@ export const tryProxyCodexWebSocket = async (
   const cacheKey = sessionId ? `${input.accountKey}:${sessionId}` : null;
   const headers = buildWebSocketHeaders(input.headers, requestId);
 
+  if (cacheKey && fallbackSocketKeys.has(cacheKey)) {
+    logCodexWebSocketLifecycle({
+      diagnosticRequestId,
+      model: body.model,
+      upstreamSessionId: input.upstreamSessionId ?? null,
+      stage: "session_fallback_active",
+      elapsedMs: Date.now() - startedAt,
+    });
+    return null;
+  }
+
   let acquired: Awaited<ReturnType<typeof acquireSocket>> | null = null;
   const fullBody = withoutTransportFields(
     sessionId ? { ...body, prompt_cache_key: requestId } : body
@@ -807,6 +865,9 @@ export const tryProxyCodexWebSocket = async (
     cacheDecision = builtRequest.decision;
   } catch (error) {
     acquired?.release(false);
+    if (!isSessionConcurrencyError(error)) {
+      markSessionFallback(cacheKey);
+    }
     logCodexWebSocketLifecycle({
       diagnosticRequestId,
       model: body.model,
@@ -829,6 +890,9 @@ export const tryProxyCodexWebSocket = async (
   let terminal = false;
   let failure: unknown = null;
   let messagesReceived = 0;
+  let emittedPayload = false;
+  let connectionLimitAttempts = 0;
+  let responseIdleTimer: ReturnType<typeof setTimeout> | null = null;
   let wake: (() => void) | null = null;
   const queue: Record<string, unknown>[] = [];
 
@@ -839,6 +903,24 @@ export const tryProxyCodexWebSocket = async (
     const resolve = wake;
     wake = null;
     resolve();
+  };
+
+  const clearResponseIdleTimer = (): void => {
+    if (!responseIdleTimer) {
+      return;
+    }
+    clearTimeout(responseIdleTimer);
+    responseIdleTimer = null;
+  };
+
+  const resetResponseIdleTimer = (stage: string): void => {
+    if (settled) {
+      return;
+    }
+    clearResponseIdleTimer();
+    responseIdleTimer = setTimeout(() => {
+      fail(stage, new Error(stage));
+    }, RESPONSE_IDLE_TIMEOUT_MS);
   };
 
   let firstPayloadResolve: ((payload: Record<string, unknown>) => void) | null =
@@ -852,10 +934,80 @@ export const tryProxyCodexWebSocket = async (
   );
 
   const cleanup = (): void => {
+    clearResponseIdleTimer();
     active.socket.removeEventListener("message", onMessage);
     active.socket.removeEventListener("error", onError);
     active.socket.removeEventListener("close", onClose);
     input.signal?.removeEventListener("abort", onAbort);
+  };
+
+  const attachSocketListeners = (): void => {
+    active.socket.addEventListener("message", onMessage);
+    active.socket.addEventListener("error", onError);
+    active.socket.addEventListener("close", onClose);
+  };
+
+  const sendRequest = (): void => {
+    try {
+      resetResponseIdleTimer("idle_timeout_sending_websocket_request");
+      active.socket.send(
+        JSON.stringify({ ...requestBody, type: "response.create" })
+      );
+      resetResponseIdleTimer("idle_timeout_waiting_for_websocket");
+    } catch (error) {
+      fail("send_failed", error);
+    }
+  };
+
+  const retryConnectionLimit = async (): Promise<void> => {
+    if (settled) {
+      return;
+    }
+    if (connectionLimitAttempts >= CONNECTION_LIMIT_RETRIES) {
+      fail(
+        "connection_limit_retries_exhausted",
+        new Error(CONNECTION_LIMIT_REACHED_CODE)
+      );
+      return;
+    }
+
+    connectionLimitAttempts++;
+    clearResponseIdleTimer();
+    active.socket.removeEventListener("message", onMessage);
+    active.socket.removeEventListener("error", onError);
+    active.socket.removeEventListener("close", onClose);
+    closeSocket(active.socket);
+    logCodexWebSocketLifecycle({
+      diagnosticRequestId,
+      model: requestBody.model,
+      upstreamSessionId: input.upstreamSessionId ?? null,
+      stage: "connection_limit_retry",
+      elapsedMs: Date.now() - startedAt,
+      cacheDecision: cacheDecision.reason,
+      retryAttempt: connectionLimitAttempts,
+      messagesReceived,
+      queueLength: queue.length,
+      terminal,
+      settled,
+      failureSet: Boolean(failure),
+      sentInputItems: inputItems(requestBody),
+      hasPreviousResponseId:
+        typeof requestBody.previous_response_id === "string",
+    });
+
+    try {
+      const nextSocket = await connectWebSocket(headers, input.signal);
+      active.socket = nextSocket;
+      if (active.cached) {
+        active.cached.socket = nextSocket;
+        active.cached.connectedAt = Date.now();
+      }
+      attachSocketListeners();
+      sendRequest();
+    } catch (error) {
+      markSessionFallback(cacheKey);
+      fail("connection_limit_retry_failed", error);
+    }
   };
 
   const fail = (stage: string, error: unknown, closeEvent?: unknown): void => {
@@ -980,6 +1132,14 @@ export const tryProxyCodexWebSocket = async (
         return;
       }
       messagesReceived++;
+      resetResponseIdleTimer("idle_timeout_waiting_for_websocket");
+
+      if (!emittedPayload && isConnectionLimitPayload(payload)) {
+        retryConnectionLimit().catch((error: unknown) => {
+          fail("connection_limit_retry_failed", error);
+        });
+        return;
+      }
 
       if (
         payload.type === "response.completed" ||
@@ -1009,6 +1169,7 @@ export const tryProxyCodexWebSocket = async (
             typeof requestBody.previous_response_id === "string",
         });
       }
+      emittedPayload = true;
       queue.push(payload);
       if (queue.length === 1) {
         firstPayloadResolve?.(payload);
@@ -1019,23 +1180,16 @@ export const tryProxyCodexWebSocket = async (
     }
   };
 
-  active.socket.addEventListener("message", onMessage);
-  active.socket.addEventListener("error", onError);
-  active.socket.addEventListener("close", onClose);
+  attachSocketListeners();
   input.signal?.addEventListener("abort", onAbort);
 
-  try {
-    active.socket.send(
-      JSON.stringify({ ...requestBody, type: "response.create" })
-    );
-  } catch (error) {
-    fail("send_failed", error);
-  }
+  sendRequest();
 
   let first: Record<string, unknown>;
   try {
     first = await firstPayload;
   } catch (error) {
+    markSessionFallback(cacheKey);
     logCodexWebSocketLifecycle({
       diagnosticRequestId,
       model: requestBody.model,
@@ -1093,6 +1247,9 @@ export const tryProxyCodexWebSocket = async (
       payload.type === "response.done" ||
       payload.type === "response.incomplete"
     ) {
+      if (payload.type === "response.incomplete") {
+        keepSocket = false;
+      }
       terminal = true;
       finalEventType = payload.type;
       finalResponseStatus = isObjectRecord(payload.response)

--- a/src/providers/proxies/codex-websocket.ts
+++ b/src/providers/proxies/codex-websocket.ts
@@ -16,6 +16,7 @@ const CONNECT_TIMEOUT_MS = 15_000;
 const RESPONSE_IDLE_TIMEOUT_MS = 5 * 60 * 1000;
 const MAX_SOCKET_AGE_MS = 55 * 60 * 1000;
 const CONNECTION_LIMIT_RETRIES = 5;
+const STREAM_FAILURE_RETRIES = 5;
 const CONNECTION_LIMIT_REACHED_CODE = "websocket_connection_limit_reached";
 const WEBSOCKET_MESSAGE_TOO_BIG_CLOSE_CODE = 1009;
 
@@ -84,6 +85,7 @@ type CacheDecision = {
 
 const socketCache = new Map<string, CachedSocket>();
 const fallbackSocketKeys = new Map<string, ReturnType<typeof setTimeout>>();
+const streamFailureCounts = new Map<string, number>();
 const pendingSocketKeys = new Set<string>();
 const suppressContinuationStoreKeys = new Set<string>();
 let diagnosticRequestCounter = 0;
@@ -212,6 +214,26 @@ const markSessionFallback = (key: string | null): void => {
   fallbackSocketKeys.set(key, timer);
 };
 
+const clearSessionStreamFailures = (key: string | null): void => {
+  if (!key) {
+    return;
+  }
+  streamFailureCounts.delete(key);
+};
+
+const recordSessionStreamFailure = (key: string | null): number => {
+  if (!key) {
+    return 0;
+  }
+
+  const failures = (streamFailureCounts.get(key) ?? 0) + 1;
+  streamFailureCounts.set(key, failures);
+  if (failures > STREAM_FAILURE_RETRIES) {
+    markSessionFallback(key);
+  }
+  return failures;
+};
+
 const scheduleExpiry = (key: string, cached: CachedSocket): void => {
   if (cached.idleTimer) {
     clearTimeout(cached.idleTimer);
@@ -225,6 +247,7 @@ const scheduleExpiry = (key: string, cached: CachedSocket): void => {
     closeSocket(cached.socket);
     socketCache.delete(key);
     clearSessionFallback(key);
+    clearSessionStreamFailures(key);
   }, SESSION_SOCKET_TTL_MS);
 };
 
@@ -414,6 +437,7 @@ export const closeCodexWebSocketSessions = (): void => {
     clearTimeout(timer);
   }
   fallbackSocketKeys.clear();
+  streamFailureCounts.clear();
 };
 
 const withoutContinuationFields = (
@@ -727,6 +751,9 @@ const isSessionConcurrencyError = (error: unknown): boolean =>
   (error.message === "Codex WebSocket session is busy" ||
     error.message === "Codex WebSocket session is connecting");
 
+const isUserCancelledStage = (stage: string): boolean =>
+  stage === "request_aborted" || stage === "downstream_cancel";
+
 const isCacheableFinalEvent = (
   eventType: unknown,
   responseStatus: string | null
@@ -775,6 +802,8 @@ const logCodexWebSocketLifecycle = (input: {
   sentInputItems?: number | null;
   hasPreviousResponseId?: boolean;
   retryAttempt?: number;
+  streamFailures?: number;
+  fallbackActive?: boolean;
 }): void => {
   logCodexWebSocketDiagnostic({
     event: "codex_compaction_ws_lifecycle",
@@ -796,6 +825,8 @@ const logCodexWebSocketLifecycle = (input: {
     sentInputItems: input.sentInputItems,
     hasPreviousResponseId: input.hasPreviousResponseId,
     retryAttempt: input.retryAttempt,
+    streamFailures: input.streamFailures,
+    fallbackActive: input.fallbackActive,
   });
 };
 
@@ -900,6 +931,8 @@ export const tryProxyCodexWebSocket = async (
       upstreamSessionId: input.upstreamSessionId ?? null,
       stage: "session_fallback_active",
       elapsedMs: Date.now() - startedAt,
+      streamFailures: streamFailureCounts.get(cacheKey) ?? 0,
+      fallbackActive: true,
     });
     return null;
   }
@@ -917,9 +950,13 @@ export const tryProxyCodexWebSocket = async (
     cacheDecision = builtRequest.decision;
   } catch (error) {
     acquired?.release(false);
+    let streamFailures: number | undefined;
     if (!isSessionConcurrencyError(error)) {
-      markSessionFallback(cacheKey);
+      streamFailures = recordSessionStreamFailure(cacheKey);
     }
+    const fallbackActive = cacheKey
+      ? fallbackSocketKeys.has(cacheKey)
+      : undefined;
     logCodexWebSocketLifecycle({
       diagnosticRequestId,
       model: body.model,
@@ -927,6 +964,8 @@ export const tryProxyCodexWebSocket = async (
       stage: "acquire_failed",
       elapsedMs: Date.now() - startedAt,
       error,
+      ...(streamFailures === undefined ? {} : { streamFailures }),
+      ...(fallbackActive === undefined ? {} : { fallbackActive }),
     });
     return null;
   }
@@ -1057,7 +1096,6 @@ export const tryProxyCodexWebSocket = async (
       attachSocketListeners();
       sendRequest();
     } catch (error) {
-      markSessionFallback(cacheKey);
       fail("connection_limit_retry_failed", error);
     }
   };
@@ -1071,6 +1109,12 @@ export const tryProxyCodexWebSocket = async (
     failure = error;
     cleanup();
     active.release(false);
+    const streamFailures = isUserCancelledStage(stage)
+      ? undefined
+      : recordSessionStreamFailure(cacheKey);
+    const fallbackActive = cacheKey
+      ? fallbackSocketKeys.has(cacheKey)
+      : undefined;
     logCodexWebSocketLifecycle({
       diagnosticRequestId,
       model: requestBody.model,
@@ -1088,6 +1132,8 @@ export const tryProxyCodexWebSocket = async (
       sentInputItems: inputItems(requestBody),
       hasPreviousResponseId:
         typeof requestBody.previous_response_id === "string",
+      ...(streamFailures === undefined ? {} : { streamFailures }),
+      ...(fallbackActive === undefined ? {} : { fallbackActive }),
     });
     firstPayloadReject?.(error);
     wakePull();
@@ -1123,6 +1169,9 @@ export const tryProxyCodexWebSocket = async (
         active.cached.continuation = null;
       }
       active.cached.skipNextContinuationStore = false;
+    }
+    if (isCacheableFinalEvent(finalEventType, finalResponseStatus)) {
+      clearSessionStreamFailures(cacheKey);
     }
     logCodexWebSocketStore({
       diagnosticRequestId,
@@ -1249,7 +1298,6 @@ export const tryProxyCodexWebSocket = async (
   try {
     first = await firstPayload;
   } catch (error) {
-    markSessionFallback(cacheKey);
     logCodexWebSocketLifecycle({
       diagnosticRequestId,
       model: requestBody.model,
@@ -1266,6 +1314,10 @@ export const tryProxyCodexWebSocket = async (
       sentInputItems: inputItems(requestBody),
       hasPreviousResponseId:
         typeof requestBody.previous_response_id === "string",
+      ...(cacheKey && streamFailureCounts.has(cacheKey)
+        ? { streamFailures: streamFailureCounts.get(cacheKey) ?? 0 }
+        : {}),
+      ...(cacheKey ? { fallbackActive: fallbackSocketKeys.has(cacheKey) } : {}),
     });
     return null;
   }

--- a/src/providers/proxies/codex-websocket.ts
+++ b/src/providers/proxies/codex-websocket.ts
@@ -64,25 +64,6 @@ type CachedSocket = {
   skipNextContinuationStore: boolean;
 };
 
-type CacheDecision = {
-  reason:
-    | "delta"
-    | "normalized_delta"
-    | "no_cached_socket"
-    | "no_continuation"
-    | "explicit_previous_response_id"
-    | "input_not_array"
-    | "cached_input_not_array"
-    | "non_input_mismatch"
-    | "input_shorter_than_baseline"
-    | "prefix_mismatch";
-  currentInputItems: number | null;
-  cachedInputItems: number | null;
-  cachedResponseItems: number | null;
-  baselineItems: number | null;
-  deltaItems: number | null;
-};
-
 const socketCache = new Map<string, CachedSocket>();
 const fallbackSocketKeys = new Map<string, ReturnType<typeof setTimeout>>();
 const streamFailureCounts = new Map<string, number>();
@@ -118,24 +99,6 @@ const readString = (value: unknown): string | null => {
   const trimmed = value.trim();
   return trimmed || null;
 };
-
-const inputItems = (body: Record<string, unknown>): number | null =>
-  Array.isArray(body.input) ? body.input.length : null;
-
-const emptyCacheDecision = (
-  reason: CacheDecision["reason"],
-  webSocketBody: Record<string, unknown>,
-  cached: CachedSocket | null
-): CacheDecision => ({
-  reason,
-  currentInputItems: inputItems(webSocketBody),
-  cachedInputItems: cached?.continuation
-    ? inputItems(cached.continuation.lastRequestBody)
-    : null,
-  cachedResponseItems: cached?.continuation?.lastResponseItems.length ?? null,
-  baselineItems: null,
-  deltaItems: null,
-});
 
 const isSocketOpen = (socket: WebSocketLike): boolean =>
   socket.readyState === undefined || socket.readyState === 1;
@@ -577,48 +540,25 @@ const matchesLoweredResponseItems = (
 const buildRequestBody = (
   webSocketBody: Record<string, unknown>,
   cached: CachedSocket | null
-): { body: Record<string, unknown>; decision: CacheDecision } => {
+): Record<string, unknown> => {
   if (!cached) {
-    return {
-      body: webSocketBody,
-      decision: emptyCacheDecision("no_cached_socket", webSocketBody, cached),
-    };
+    return webSocketBody;
   }
   if (!cached.continuation) {
-    return {
-      body: webSocketBody,
-      decision: emptyCacheDecision("no_continuation", webSocketBody, cached),
-    };
+    return webSocketBody;
   }
   if (hasOwn(webSocketBody, "previous_response_id")) {
-    return {
-      body: webSocketBody,
-      decision: emptyCacheDecision(
-        "explicit_previous_response_id",
-        webSocketBody,
-        cached
-      ),
-    };
+    return webSocketBody;
   }
   if (!Array.isArray(webSocketBody.input)) {
-    const decision = emptyCacheDecision(
-      "input_not_array",
-      webSocketBody,
-      cached
-    );
     cached.continuation = null;
-    return { body: webSocketBody, decision };
+    return webSocketBody;
   }
 
   const { continuation } = cached;
   if (!Array.isArray(continuation.lastRequestBody.input)) {
-    const decision = emptyCacheDecision(
-      "cached_input_not_array",
-      webSocketBody,
-      cached
-    );
     cached.continuation = null;
-    return { body: webSocketBody, decision };
+    return webSocketBody;
   }
   if (
     !sameJson(
@@ -626,13 +566,8 @@ const buildRequestBody = (
       withoutContinuationFields(continuation.lastRequestBody)
     )
   ) {
-    const decision = emptyCacheDecision(
-      "non_input_mismatch",
-      webSocketBody,
-      cached
-    );
     cached.continuation = null;
-    return { body: webSocketBody, decision };
+    return webSocketBody;
   }
 
   const baseline = [
@@ -640,16 +575,8 @@ const buildRequestBody = (
     ...continuation.lastResponseItems,
   ];
   if (webSocketBody.input.length < baseline.length) {
-    const decision = {
-      ...emptyCacheDecision(
-        "input_shorter_than_baseline",
-        webSocketBody,
-        cached
-      ),
-      baselineItems: baseline.length,
-    };
     cached.continuation = null;
-    return { body: webSocketBody, decision };
+    return webSocketBody;
   }
 
   const prefix = webSocketBody.input.slice(0, baseline.length);
@@ -668,44 +595,29 @@ const buildRequestBody = (
     ) {
       const delta = webSocketBody.input.slice(baseline.length);
       return {
-        body: {
-          ...webSocketBody,
-          previous_response_id: continuation.lastResponseId,
-          input: delta,
-        },
-        decision: {
-          ...emptyCacheDecision("normalized_delta", webSocketBody, cached),
-          baselineItems: baseline.length,
-          deltaItems: delta.length,
-        },
+        ...webSocketBody,
+        previous_response_id: continuation.lastResponseId,
+        input: delta,
       };
     }
 
-    const decision = {
-      ...emptyCacheDecision("prefix_mismatch", webSocketBody, cached),
-      baselineItems: baseline.length,
-    };
     cached.continuation = null;
-    return { body: webSocketBody, decision };
+    return webSocketBody;
   }
 
   const delta = webSocketBody.input.slice(baseline.length);
   return {
-    body: {
-      ...webSocketBody,
-      previous_response_id: continuation.lastResponseId,
-      input: delta,
-    },
-    decision: {
-      ...emptyCacheDecision("delta", webSocketBody, cached),
-      baselineItems: baseline.length,
-      deltaItems: delta.length,
-    },
+    ...webSocketBody,
+    previous_response_id: continuation.lastResponseId,
+    input: delta,
   };
 };
 
 const encodeSse = (payload: unknown): Uint8Array =>
   new TextEncoder().encode(`data: ${JSON.stringify(payload)}\n\n`);
+
+const encodeDoneSse = (): Uint8Array =>
+  new TextEncoder().encode("data: [DONE]\n\n");
 
 const decodeMessageData = async (data: unknown): Promise<string | null> => {
   if (typeof data === "string") {
@@ -768,8 +680,13 @@ const buildWebSocketHeaders = (
 ): Headers => {
   const nextHeaders = new Headers(headers);
   nextHeaders.delete("accept");
+  nextHeaders.delete("connection");
+  nextHeaders.delete("content-length");
   nextHeaders.delete("content-type");
+  nextHeaders.delete("host");
   nextHeaders.delete("openai-beta");
+  nextHeaders.delete("transfer-encoding");
+  nextHeaders.delete("upgrade");
   nextHeaders.set("OpenAI-Beta", CODEX_WEBSOCKET_BETA_HEADER);
   applyCodexSessionHeaders(nextHeaders, requestId);
   return nextHeaders;
@@ -807,8 +724,7 @@ export const tryProxyCodexWebSocket = async (
   let requestBody: Record<string, unknown>;
   try {
     acquired = await acquireSocket(headers, cacheKey, input.signal);
-    const builtRequest = buildRequestBody(fullBody, acquired.cached);
-    requestBody = builtRequest.body;
+    requestBody = buildRequestBody(fullBody, acquired.cached);
   } catch (error) {
     acquired?.release(false);
     if (!input.signal?.aborted && !isSessionConcurrencyError(error)) {
@@ -887,6 +803,13 @@ export const tryProxyCodexWebSocket = async (
   };
 
   const sendRequest = (): void => {
+    if (settled) {
+      return;
+    }
+    if (input.signal?.aborted) {
+      fail("request_aborted", new Error("Request was aborted"));
+      return;
+    }
     try {
       active.socket.send(
         JSON.stringify({ ...requestBody, type: "response.create" })
@@ -988,11 +911,20 @@ export const tryProxyCodexWebSocket = async (
     fail("socket_error", extractWebSocketError(event));
 
   const onClose = (event: unknown): void => {
-    if (terminal) {
-      wakePull();
-      return;
-    }
-    fail("socket_closed_before_terminal", extractWebSocketCloseError(event));
+    messageChain = messageChain
+      .then(() => {
+        if (terminal) {
+          wakePull();
+          return;
+        }
+        fail(
+          "socket_closed_before_terminal",
+          extractWebSocketCloseError(event)
+        );
+      })
+      .catch((error: unknown) => {
+        fail("message_parse_failed", error);
+      });
   };
 
   const handleMessage = async (event: unknown): Promise<void> => {
@@ -1090,6 +1022,7 @@ export const tryProxyCodexWebSocket = async (
       finalResponseStatus = isObjectRecord(payload.response)
         ? readString(payload.response.status)
         : null;
+      controller.enqueue(encodeDoneSse());
       finish();
     }
   };

--- a/src/providers/proxies/codex-websocket.ts
+++ b/src/providers/proxies/codex-websocket.ts
@@ -79,6 +79,12 @@ type CacheDecision = {
 const socketCache = new Map<string, CachedSocket>();
 const pendingSocketKeys = new Set<string>();
 const suppressContinuationStoreKeys = new Set<string>();
+let diagnosticRequestCounter = 0;
+
+const nextDiagnosticRequestId = (): string => {
+  diagnosticRequestCounter = (diagnosticRequestCounter + 1) % 1_000_000;
+  return `${Date.now().toString(36)}-${diagnosticRequestCounter.toString(36)}`;
+};
 
 const resolveCodexWebSocketUrl = (): string => {
   const url = new URL(CODEX_RESPONSE_ENDPOINT);
@@ -640,7 +646,62 @@ const logCodexWebSocketDiagnostic = (
   process.stderr.write(`${JSON.stringify(payload)}\n`);
 };
 
+const errorShape = (error: unknown): Record<string, unknown> => ({
+  name: error instanceof Error ? error.name : typeof error,
+  message: error instanceof Error ? error.message : String(error),
+});
+
+const closeEventShape = (event: unknown): Record<string, unknown> | null => {
+  if (!isObjectRecord(event)) {
+    return null;
+  }
+  return {
+    code: typeof event.code === "number" ? event.code : null,
+    wasClean: typeof event.wasClean === "boolean" ? event.wasClean : null,
+  };
+};
+
+const logCodexWebSocketLifecycle = (input: {
+  diagnosticRequestId: string;
+  model: unknown;
+  upstreamSessionId: string | null;
+  stage: string;
+  elapsedMs: number;
+  cacheDecision?: string;
+  error?: unknown;
+  closeEvent?: unknown;
+  messagesReceived?: number;
+  queueLength?: number;
+  terminal?: boolean;
+  settled?: boolean;
+  failureSet?: boolean;
+  sentInputItems?: number | null;
+  hasPreviousResponseId?: boolean;
+}): void => {
+  logCodexWebSocketDiagnostic({
+    event: "codex_compaction_ws_lifecycle",
+    diagnosticRequestId: input.diagnosticRequestId,
+    model: readString(input.model),
+    sessionHash: sessionHash(input.upstreamSessionId),
+    stage: input.stage,
+    elapsedMs: input.elapsedMs,
+    cacheDecision: input.cacheDecision,
+    ...(input.error ? { error: errorShape(input.error) } : {}),
+    ...(input.closeEvent
+      ? { closeEvent: closeEventShape(input.closeEvent) }
+      : {}),
+    messagesReceived: input.messagesReceived,
+    queueLength: input.queueLength,
+    terminal: input.terminal,
+    settled: input.settled,
+    failureSet: input.failureSet,
+    sentInputItems: input.sentInputItems,
+    hasPreviousResponseId: input.hasPreviousResponseId,
+  });
+};
+
 const logCodexWebSocketDecision = (input: {
+  diagnosticRequestId: string;
   model: unknown;
   upstreamSessionId: string | null;
   decision: CacheDecision;
@@ -649,6 +710,7 @@ const logCodexWebSocketDecision = (input: {
 }): void => {
   logCodexWebSocketDiagnostic({
     event: "codex_compaction_ws_decision",
+    diagnosticRequestId: input.diagnosticRequestId,
     model: readString(input.model),
     sessionHash: sessionHash(input.upstreamSessionId),
     cacheDecision: input.decision.reason,
@@ -668,8 +730,10 @@ const logCodexWebSocketDecision = (input: {
 };
 
 const logCodexWebSocketStore = (input: {
+  diagnosticRequestId: string;
   model: unknown;
   upstreamSessionId: string | null;
+  elapsedMs: number;
   keptSocket: boolean;
   responseIdPresent: boolean;
   responseItems: number;
@@ -680,8 +744,10 @@ const logCodexWebSocketStore = (input: {
 }): void => {
   logCodexWebSocketDiagnostic({
     event: "codex_compaction_ws_store",
+    diagnosticRequestId: input.diagnosticRequestId,
     model: readString(input.model),
     sessionHash: sessionHash(input.upstreamSessionId),
+    elapsedMs: input.elapsedMs,
     keptSocket: input.keptSocket,
     responseIdPresent: input.responseIdPresent,
     responseItems: input.responseItems,
@@ -708,6 +774,8 @@ const buildWebSocketHeaders = (
 export const tryProxyCodexWebSocket = async (
   input: CodexWebSocketInput
 ): Promise<Response | null> => {
+  const diagnosticRequestId = nextDiagnosticRequestId();
+  const startedAt = Date.now();
   const body = input.bodyJson;
   if (
     !body ||
@@ -737,8 +805,16 @@ export const tryProxyCodexWebSocket = async (
     const builtRequest = buildRequestBody(fullBody, acquired.cached);
     requestBody = builtRequest.body;
     cacheDecision = builtRequest.decision;
-  } catch {
+  } catch (error) {
     acquired?.release(false);
+    logCodexWebSocketLifecycle({
+      diagnosticRequestId,
+      model: body.model,
+      upstreamSessionId: input.upstreamSessionId ?? null,
+      stage: "acquire_failed",
+      elapsedMs: Date.now() - startedAt,
+      error,
+    });
     return null;
   }
 
@@ -752,6 +828,7 @@ export const tryProxyCodexWebSocket = async (
   let settled = false;
   let terminal = false;
   let failure: unknown = null;
+  let messagesReceived = 0;
   let wake: (() => void) | null = null;
   const queue: Record<string, unknown>[] = [];
 
@@ -781,7 +858,7 @@ export const tryProxyCodexWebSocket = async (
     input.signal?.removeEventListener("abort", onAbort);
   };
 
-  const fail = (error: unknown): void => {
+  const fail = (stage: string, error: unknown, closeEvent?: unknown): void => {
     if (settled) {
       return;
     }
@@ -790,6 +867,24 @@ export const tryProxyCodexWebSocket = async (
     failure = error;
     cleanup();
     active.release(false);
+    logCodexWebSocketLifecycle({
+      diagnosticRequestId,
+      model: requestBody.model,
+      upstreamSessionId: input.upstreamSessionId ?? null,
+      stage,
+      elapsedMs: Date.now() - startedAt,
+      cacheDecision: cacheDecision.reason,
+      error,
+      closeEvent,
+      messagesReceived,
+      queueLength: queue.length,
+      terminal,
+      settled,
+      failureSet: true,
+      sentInputItems: inputItems(requestBody),
+      hasPreviousResponseId:
+        typeof requestBody.previous_response_id === "string",
+    });
     firstPayloadReject?.(error);
     wakePull();
   };
@@ -826,8 +921,10 @@ export const tryProxyCodexWebSocket = async (
       active.cached.skipNextContinuationStore = false;
     }
     logCodexWebSocketStore({
+      diagnosticRequestId,
       model: requestBody.model,
       upstreamSessionId: input.upstreamSessionId ?? null,
+      elapsedMs: Date.now() - startedAt,
       keptSocket: keepSocket,
       responseIdPresent: Boolean(responseId),
       responseItems: responseItems.length,
@@ -840,16 +937,35 @@ export const tryProxyCodexWebSocket = async (
     wakePull();
   };
 
-  const onAbort = (): void => fail(new Error("Request was aborted"));
+  const onAbort = (): void =>
+    fail("request_aborted", new Error("Request was aborted"));
 
-  const onError = (): void => fail(new Error("WebSocket error"));
+  const onError = (): void =>
+    fail("socket_error", new Error("WebSocket error"));
 
-  const onClose = (): void => {
+  const onClose = (event: unknown): void => {
     if (terminal) {
+      logCodexWebSocketLifecycle({
+        diagnosticRequestId,
+        model: requestBody.model,
+        upstreamSessionId: input.upstreamSessionId ?? null,
+        stage: "socket_closed_after_terminal",
+        elapsedMs: Date.now() - startedAt,
+        cacheDecision: cacheDecision.reason,
+        closeEvent: event,
+        messagesReceived,
+        queueLength: queue.length,
+        terminal,
+        settled,
+        failureSet: Boolean(failure),
+        sentInputItems: inputItems(requestBody),
+        hasPreviousResponseId:
+          typeof requestBody.previous_response_id === "string",
+      });
       wakePull();
       return;
     }
-    fail(new Error("WebSocket closed"));
+    fail("socket_closed_before_terminal", new Error("WebSocket closed"), event);
   };
 
   const onMessage = (event: unknown): void => {
@@ -863,6 +979,7 @@ export const tryProxyCodexWebSocket = async (
       if (!isObjectRecord(payload)) {
         return;
       }
+      messagesReceived++;
 
       if (
         payload.type === "response.completed" ||
@@ -875,6 +992,22 @@ export const tryProxyCodexWebSocket = async (
         finalResponseStatus = isObjectRecord(payload.response)
           ? readString(payload.response.status)
           : null;
+        logCodexWebSocketLifecycle({
+          diagnosticRequestId,
+          model: requestBody.model,
+          upstreamSessionId: input.upstreamSessionId ?? null,
+          stage: "upstream_terminal_received",
+          elapsedMs: Date.now() - startedAt,
+          cacheDecision: cacheDecision.reason,
+          messagesReceived,
+          queueLength: queue.length,
+          terminal,
+          settled,
+          failureSet: Boolean(failure),
+          sentInputItems: inputItems(requestBody),
+          hasPreviousResponseId:
+            typeof requestBody.previous_response_id === "string",
+        });
       }
       queue.push(payload);
       if (queue.length === 1) {
@@ -882,7 +1015,7 @@ export const tryProxyCodexWebSocket = async (
       }
       wakePull();
     } catch (error) {
-      fail(error);
+      fail("message_parse_failed", error);
     }
   };
 
@@ -896,17 +1029,35 @@ export const tryProxyCodexWebSocket = async (
       JSON.stringify({ ...requestBody, type: "response.create" })
     );
   } catch (error) {
-    fail(error);
+    fail("send_failed", error);
   }
 
   let first: Record<string, unknown>;
   try {
     first = await firstPayload;
-  } catch {
+  } catch (error) {
+    logCodexWebSocketLifecycle({
+      diagnosticRequestId,
+      model: requestBody.model,
+      upstreamSessionId: input.upstreamSessionId ?? null,
+      stage: "first_payload_failed",
+      elapsedMs: Date.now() - startedAt,
+      cacheDecision: cacheDecision.reason,
+      error,
+      messagesReceived,
+      queueLength: queue.length,
+      terminal,
+      settled,
+      failureSet: Boolean(failure),
+      sentInputItems: inputItems(requestBody),
+      hasPreviousResponseId:
+        typeof requestBody.previous_response_id === "string",
+    });
     return null;
   }
 
   logCodexWebSocketDecision({
+    diagnosticRequestId,
     model: requestBody.model,
     upstreamSessionId: input.upstreamSessionId ?? null,
     decision: cacheDecision,
@@ -970,7 +1121,12 @@ export const tryProxyCodexWebSocket = async (
       if (queue.length) {
         const payload = queue.shift();
         if (payload) {
-          processPayload(payload, controller);
+          try {
+            processPayload(payload, controller);
+          } catch (error) {
+            fail("downstream_enqueue_failed", error);
+            controller.error(error);
+          }
         }
         return;
       }
@@ -984,9 +1140,25 @@ export const tryProxyCodexWebSocket = async (
     },
     cancel(): void {
       if (settled) {
+        logCodexWebSocketLifecycle({
+          diagnosticRequestId,
+          model: requestBody.model,
+          upstreamSessionId: input.upstreamSessionId ?? null,
+          stage: "downstream_cancel_after_settled",
+          elapsedMs: Date.now() - startedAt,
+          cacheDecision: cacheDecision.reason,
+          messagesReceived,
+          queueLength: queue.length,
+          terminal,
+          settled,
+          failureSet: Boolean(failure),
+          sentInputItems: inputItems(requestBody),
+          hasPreviousResponseId:
+            typeof requestBody.previous_response_id === "string",
+        });
         return;
       }
-      fail(new Error("Response stream was cancelled"));
+      fail("downstream_cancel", new Error("Response stream was cancelled"));
     },
   });
 

--- a/src/providers/proxies/codex-websocket.ts
+++ b/src/providers/proxies/codex-websocket.ts
@@ -17,6 +17,7 @@ const RESPONSE_IDLE_TIMEOUT_MS = 5 * 60 * 1000;
 const MAX_SOCKET_AGE_MS = 55 * 60 * 1000;
 const CONNECTION_LIMIT_RETRIES = 5;
 const CONNECTION_LIMIT_REACHED_CODE = "websocket_connection_limit_reached";
+const WEBSOCKET_MESSAGE_TOO_BIG_CLOSE_CODE = 1009;
 
 type WebSocketEventType = "open" | "message" | "error" | "close";
 type WebSocketListener = (event: unknown) => void;
@@ -154,6 +155,44 @@ const closeSocket = (socket: WebSocketLike): void => {
   }
 };
 
+const extractWebSocketError = (event: unknown): Error => {
+  if (isObjectRecord(event)) {
+    const message = readString(event.message);
+    if (message) {
+      return new Error(message);
+    }
+
+    const nestedError = event.error;
+    if (nestedError instanceof Error && nestedError.message) {
+      return nestedError;
+    }
+    if (isObjectRecord(nestedError)) {
+      const nestedMessage = readString(nestedError.message);
+      if (nestedMessage) {
+        return new Error(nestedMessage);
+      }
+    }
+  }
+
+  return new Error("WebSocket error");
+};
+
+const extractWebSocketCloseError = (event: unknown): Error => {
+  if (!isObjectRecord(event)) {
+    return new Error("WebSocket closed");
+  }
+
+  const code = typeof event.code === "number" ? event.code : null;
+  const reason = readString(event.reason);
+  const codeText = code === null ? "" : ` ${code}`;
+  const reasonText =
+    reason ??
+    (code === WEBSOCKET_MESSAGE_TOO_BIG_CLOSE_CODE ? "message too big" : null);
+  return new Error(
+    `WebSocket closed${codeText}${reasonText ? ` ${reasonText}` : ""}`.trim()
+  );
+};
+
 const clearSessionFallback = (key: string): void => {
   const timer = fallbackSocketKeys.get(key);
   if (timer) {
@@ -239,15 +278,19 @@ const connectWebSocket = (
       cleanup();
       resolve(socket);
     };
-    const onError = (): void => fail(new Error("WebSocket error"));
-    const onClose = (): void => fail(new Error("WebSocket closed"));
+    const onError = (event: unknown): void =>
+      fail(extractWebSocketError(event));
+    const onClose = (event: unknown): void =>
+      fail(extractWebSocketCloseError(event));
     const onAbort = (): void => {
       closeSocket(socket);
       fail(new Error("Request was aborted"));
     };
     const onTimeout = (): void => {
       closeSocket(socket);
-      fail(new Error("WebSocket connect timed out"));
+      fail(
+        new Error(`WebSocket connect timeout after ${CONNECT_TIMEOUT_MS}ms`)
+      );
     };
 
     try {
@@ -645,12 +688,21 @@ const buildRequestBody = (
 const encodeSse = (payload: unknown): Uint8Array =>
   new TextEncoder().encode(`data: ${JSON.stringify(payload)}\n\n`);
 
-const decodeMessageData = (data: unknown): string | null => {
+const decodeMessageData = async (data: unknown): Promise<string | null> => {
   if (typeof data === "string") {
     return data;
   }
-  if (data instanceof ArrayBuffer || ArrayBuffer.isView(data)) {
-    return new TextDecoder().decode(data);
+  if (data instanceof ArrayBuffer) {
+    return new TextDecoder().decode(new Uint8Array(data));
+  }
+  if (ArrayBuffer.isView(data)) {
+    return new TextDecoder().decode(
+      new Uint8Array(data.buffer, data.byteOffset, data.byteLength)
+    );
+  }
+  if (isObjectRecord(data) && typeof data.arrayBuffer === "function") {
+    const arrayBuffer = (await data.arrayBuffer()) as ArrayBuffer;
+    return new TextDecoder().decode(new Uint8Array(arrayBuffer));
   }
   return null;
 };
@@ -1092,8 +1144,8 @@ export const tryProxyCodexWebSocket = async (
   const onAbort = (): void =>
     fail("request_aborted", new Error("Request was aborted"));
 
-  const onError = (): void =>
-    fail("socket_error", new Error("WebSocket error"));
+  const onError = (event: unknown): void =>
+    fail("socket_error", extractWebSocketError(event));
 
   const onClose = (event: unknown): void => {
     if (terminal) {
@@ -1117,67 +1169,75 @@ export const tryProxyCodexWebSocket = async (
       wakePull();
       return;
     }
-    fail("socket_closed_before_terminal", new Error("WebSocket closed"), event);
+    fail(
+      "socket_closed_before_terminal",
+      extractWebSocketCloseError(event),
+      event
+    );
+  };
+
+  const handleMessage = async (event: unknown): Promise<void> => {
+    const text = await decodeMessageData(
+      isObjectRecord(event) ? event.data : null
+    );
+    if (!text) {
+      return;
+    }
+
+    const payload = JSON.parse(text) as unknown;
+    if (!isObjectRecord(payload)) {
+      return;
+    }
+    messagesReceived++;
+    resetResponseIdleTimer("idle_timeout_waiting_for_websocket");
+
+    if (!emittedPayload && isConnectionLimitPayload(payload)) {
+      retryConnectionLimit().catch((error: unknown) => {
+        fail("connection_limit_retry_failed", error);
+      });
+      return;
+    }
+
+    if (
+      payload.type === "response.completed" ||
+      payload.type === "response.done" ||
+      payload.type === "response.incomplete" ||
+      isErrorPayload(payload)
+    ) {
+      terminal = true;
+      finalEventType = payload.type;
+      finalResponseStatus = isObjectRecord(payload.response)
+        ? readString(payload.response.status)
+        : null;
+      logCodexWebSocketLifecycle({
+        diagnosticRequestId,
+        model: requestBody.model,
+        upstreamSessionId: input.upstreamSessionId ?? null,
+        stage: "upstream_terminal_received",
+        elapsedMs: Date.now() - startedAt,
+        cacheDecision: cacheDecision.reason,
+        messagesReceived,
+        queueLength: queue.length,
+        terminal,
+        settled,
+        failureSet: Boolean(failure),
+        sentInputItems: inputItems(requestBody),
+        hasPreviousResponseId:
+          typeof requestBody.previous_response_id === "string",
+      });
+    }
+    emittedPayload = true;
+    queue.push(payload);
+    if (queue.length === 1) {
+      firstPayloadResolve?.(payload);
+    }
+    wakePull();
   };
 
   const onMessage = (event: unknown): void => {
-    try {
-      const text = decodeMessageData(isObjectRecord(event) ? event.data : null);
-      if (!text) {
-        return;
-      }
-
-      const payload = JSON.parse(text) as unknown;
-      if (!isObjectRecord(payload)) {
-        return;
-      }
-      messagesReceived++;
-      resetResponseIdleTimer("idle_timeout_waiting_for_websocket");
-
-      if (!emittedPayload && isConnectionLimitPayload(payload)) {
-        retryConnectionLimit().catch((error: unknown) => {
-          fail("connection_limit_retry_failed", error);
-        });
-        return;
-      }
-
-      if (
-        payload.type === "response.completed" ||
-        payload.type === "response.done" ||
-        payload.type === "response.incomplete" ||
-        isErrorPayload(payload)
-      ) {
-        terminal = true;
-        finalEventType = payload.type;
-        finalResponseStatus = isObjectRecord(payload.response)
-          ? readString(payload.response.status)
-          : null;
-        logCodexWebSocketLifecycle({
-          diagnosticRequestId,
-          model: requestBody.model,
-          upstreamSessionId: input.upstreamSessionId ?? null,
-          stage: "upstream_terminal_received",
-          elapsedMs: Date.now() - startedAt,
-          cacheDecision: cacheDecision.reason,
-          messagesReceived,
-          queueLength: queue.length,
-          terminal,
-          settled,
-          failureSet: Boolean(failure),
-          sentInputItems: inputItems(requestBody),
-          hasPreviousResponseId:
-            typeof requestBody.previous_response_id === "string",
-        });
-      }
-      emittedPayload = true;
-      queue.push(payload);
-      if (queue.length === 1) {
-        firstPayloadResolve?.(payload);
-      }
-      wakePull();
-    } catch (error) {
+    handleMessage(event).catch((error: unknown) => {
       fail("message_parse_failed", error);
-    }
+    });
   };
 
   attachSocketListeners();

--- a/src/providers/proxies/codex-websocket.ts
+++ b/src/providers/proxies/codex-websocket.ts
@@ -57,6 +57,25 @@ type CachedSocket = {
   skipNextContinuationStore: boolean;
 };
 
+type CacheDecision = {
+  reason:
+    | "delta"
+    | "normalized_delta"
+    | "no_cached_socket"
+    | "no_continuation"
+    | "explicit_previous_response_id"
+    | "input_not_array"
+    | "cached_input_not_array"
+    | "non_input_mismatch"
+    | "input_shorter_than_baseline"
+    | "prefix_mismatch";
+  currentInputItems: number | null;
+  cachedInputItems: number | null;
+  cachedResponseItems: number | null;
+  baselineItems: number | null;
+  deltaItems: number | null;
+};
+
 const socketCache = new Map<string, CachedSocket>();
 const pendingSocketKeys = new Set<string>();
 const suppressContinuationStoreKeys = new Set<string>();
@@ -90,6 +109,24 @@ const readString = (value: unknown): string | null => {
   const trimmed = value.trim();
   return trimmed || null;
 };
+
+const inputItems = (body: Record<string, unknown>): number | null =>
+  Array.isArray(body.input) ? body.input.length : null;
+
+const emptyCacheDecision = (
+  reason: CacheDecision["reason"],
+  webSocketBody: Record<string, unknown>,
+  cached: CachedSocket | null
+): CacheDecision => ({
+  reason,
+  currentInputItems: inputItems(webSocketBody),
+  cachedInputItems: cached?.continuation
+    ? inputItems(cached.continuation.lastRequestBody)
+    : null,
+  cachedResponseItems: cached?.continuation?.lastResponseItems.length ?? null,
+  baselineItems: null,
+  deltaItems: null,
+});
 
 const isSocketOpen = (socket: WebSocketLike): boolean =>
   socket.readyState === undefined || socket.readyState === 1;
@@ -437,25 +474,48 @@ const matchesLoweredResponseItems = (
 const buildRequestBody = (
   webSocketBody: Record<string, unknown>,
   cached: CachedSocket | null
-): Record<string, unknown> => {
+): { body: Record<string, unknown>; decision: CacheDecision } => {
   if (!cached) {
-    return webSocketBody;
+    return {
+      body: webSocketBody,
+      decision: emptyCacheDecision("no_cached_socket", webSocketBody, cached),
+    };
   }
   if (!cached.continuation) {
-    return webSocketBody;
+    return {
+      body: webSocketBody,
+      decision: emptyCacheDecision("no_continuation", webSocketBody, cached),
+    };
   }
   if (hasOwn(webSocketBody, "previous_response_id")) {
-    return webSocketBody;
+    return {
+      body: webSocketBody,
+      decision: emptyCacheDecision(
+        "explicit_previous_response_id",
+        webSocketBody,
+        cached
+      ),
+    };
   }
   if (!Array.isArray(webSocketBody.input)) {
+    const decision = emptyCacheDecision(
+      "input_not_array",
+      webSocketBody,
+      cached
+    );
     cached.continuation = null;
-    return webSocketBody;
+    return { body: webSocketBody, decision };
   }
 
   const { continuation } = cached;
   if (!Array.isArray(continuation.lastRequestBody.input)) {
+    const decision = emptyCacheDecision(
+      "cached_input_not_array",
+      webSocketBody,
+      cached
+    );
     cached.continuation = null;
-    return webSocketBody;
+    return { body: webSocketBody, decision };
   }
   if (
     !sameJson(
@@ -463,8 +523,13 @@ const buildRequestBody = (
       withoutContinuationFields(continuation.lastRequestBody)
     )
   ) {
+    const decision = emptyCacheDecision(
+      "non_input_mismatch",
+      webSocketBody,
+      cached
+    );
     cached.continuation = null;
-    return webSocketBody;
+    return { body: webSocketBody, decision };
   }
 
   const baseline = [
@@ -472,8 +537,16 @@ const buildRequestBody = (
     ...continuation.lastResponseItems,
   ];
   if (webSocketBody.input.length < baseline.length) {
+    const decision = {
+      ...emptyCacheDecision(
+        "input_shorter_than_baseline",
+        webSocketBody,
+        cached
+      ),
+      baselineItems: baseline.length,
+    };
     cached.continuation = null;
-    return webSocketBody;
+    return { body: webSocketBody, decision };
   }
 
   const prefix = webSocketBody.input.slice(0, baseline.length);
@@ -492,21 +565,39 @@ const buildRequestBody = (
     ) {
       const delta = webSocketBody.input.slice(baseline.length);
       return {
-        ...webSocketBody,
-        previous_response_id: continuation.lastResponseId,
-        input: delta,
+        body: {
+          ...webSocketBody,
+          previous_response_id: continuation.lastResponseId,
+          input: delta,
+        },
+        decision: {
+          ...emptyCacheDecision("normalized_delta", webSocketBody, cached),
+          baselineItems: baseline.length,
+          deltaItems: delta.length,
+        },
       };
     }
 
+    const decision = {
+      ...emptyCacheDecision("prefix_mismatch", webSocketBody, cached),
+      baselineItems: baseline.length,
+    };
     cached.continuation = null;
-    return webSocketBody;
+    return { body: webSocketBody, decision };
   }
 
   const delta = webSocketBody.input.slice(baseline.length);
   return {
-    ...webSocketBody,
-    previous_response_id: continuation.lastResponseId,
-    input: delta,
+    body: {
+      ...webSocketBody,
+      previous_response_id: continuation.lastResponseId,
+      input: delta,
+    },
+    decision: {
+      ...emptyCacheDecision("delta", webSocketBody, cached),
+      baselineItems: baseline.length,
+      deltaItems: delta.length,
+    },
   };
 };
 
@@ -539,6 +630,67 @@ const isCacheableFinalEvent = (
 ): boolean =>
   (eventType === "response.completed" || eventType === "response.done") &&
   (!responseStatus || responseStatus === "completed");
+
+const sessionHash = (sessionId: string | null | undefined): string | null =>
+  sessionId ? sessionId.replace(/^kleis_/, "").slice(0, 16) : null;
+
+const logCodexWebSocketDiagnostic = (
+  payload: Record<string, unknown>
+): void => {
+  process.stderr.write(`${JSON.stringify(payload)}\n`);
+};
+
+const logCodexWebSocketDecision = (input: {
+  model: unknown;
+  upstreamSessionId: string | null;
+  decision: CacheDecision;
+  requestBody: Record<string, unknown>;
+  firstEventType: unknown;
+}): void => {
+  logCodexWebSocketDiagnostic({
+    event: "codex_compaction_ws_decision",
+    model: readString(input.model),
+    sessionHash: sessionHash(input.upstreamSessionId),
+    cacheDecision: input.decision.reason,
+    cachedDelta:
+      input.decision.reason === "delta" ||
+      input.decision.reason === "normalized_delta",
+    currentInputItems: input.decision.currentInputItems,
+    cachedInputItems: input.decision.cachedInputItems,
+    cachedResponseItems: input.decision.cachedResponseItems,
+    baselineItems: input.decision.baselineItems,
+    deltaItems: input.decision.deltaItems,
+    sentInputItems: inputItems(input.requestBody),
+    hasPreviousResponseId:
+      typeof input.requestBody.previous_response_id === "string",
+    firstEventType: readString(input.firstEventType),
+  });
+};
+
+const logCodexWebSocketStore = (input: {
+  model: unknown;
+  upstreamSessionId: string | null;
+  keptSocket: boolean;
+  responseIdPresent: boolean;
+  responseItems: number;
+  storedContinuation: boolean;
+  finalEventType: unknown;
+  finalResponseStatus: string | null;
+  skippedStore: boolean;
+}): void => {
+  logCodexWebSocketDiagnostic({
+    event: "codex_compaction_ws_store",
+    model: readString(input.model),
+    sessionHash: sessionHash(input.upstreamSessionId),
+    keptSocket: input.keptSocket,
+    responseIdPresent: input.responseIdPresent,
+    responseItems: input.responseItems,
+    storedContinuation: input.storedContinuation,
+    finalEventType: readString(input.finalEventType),
+    finalResponseStatus: input.finalResponseStatus,
+    skippedStore: input.skippedStore,
+  });
+};
 
 const buildWebSocketHeaders = (
   headers: Headers,
@@ -579,9 +731,12 @@ export const tryProxyCodexWebSocket = async (
     sessionId ? { ...body, prompt_cache_key: requestId } : body
   );
   let requestBody: Record<string, unknown>;
+  let cacheDecision: CacheDecision;
   try {
     acquired = await acquireSocket(headers, cacheKey, input.signal);
-    requestBody = buildRequestBody(fullBody, acquired.cached);
+    const builtRequest = buildRequestBody(fullBody, acquired.cached);
+    requestBody = builtRequest.body;
+    cacheDecision = builtRequest.decision;
   } catch {
     acquired?.release(false);
     return null;
@@ -645,6 +800,14 @@ export const tryProxyCodexWebSocket = async (
     }
     settled = true;
     cleanup();
+    const skippedStore = active.cached?.skipNextContinuationStore ?? false;
+    const storedContinuation = Boolean(
+      active.cached &&
+        keepSocket &&
+        responseId &&
+        isCacheableFinalEvent(finalEventType, finalResponseStatus) &&
+        !active.cached.skipNextContinuationStore
+    );
     if (active.cached) {
       if (
         keepSocket &&
@@ -662,6 +825,17 @@ export const tryProxyCodexWebSocket = async (
       }
       active.cached.skipNextContinuationStore = false;
     }
+    logCodexWebSocketStore({
+      model: requestBody.model,
+      upstreamSessionId: input.upstreamSessionId ?? null,
+      keptSocket: keepSocket,
+      responseIdPresent: Boolean(responseId),
+      responseItems: responseItems.length,
+      storedContinuation,
+      finalEventType,
+      finalResponseStatus,
+      skippedStore,
+    });
     active.release(keepSocket);
     wakePull();
   };
@@ -731,6 +905,14 @@ export const tryProxyCodexWebSocket = async (
   } catch {
     return null;
   }
+
+  logCodexWebSocketDecision({
+    model: requestBody.model,
+    upstreamSessionId: input.upstreamSessionId ?? null,
+    decision: cacheDecision,
+    requestBody,
+    firstEventType: first.type,
+  });
 
   if (isErrorPayload(first)) {
     keepSocket = false;

--- a/tests/domain/models-dev-contract.test.ts
+++ b/tests/domain/models-dev-contract.test.ts
@@ -16,6 +16,14 @@ const upstreamRegistry = {
           npm: "@ai-sdk/openai",
         },
       },
+      "gpt-5.3-codex-spark": {
+        id: "gpt-5.3-codex-spark",
+        name: "GPT-5.3 Codex Spark",
+        provider: {
+          api: "https://api.openai.com/v1",
+          npm: "@ai-sdk/openai",
+        },
+      },
       "gpt-5": {
         id: "gpt-5",
         name: "GPT-5",
@@ -130,6 +138,9 @@ describe("models registry contract", () => {
     };
     expect(kleis.env).toEqual(["KLEIS_API_KEY"]);
     expect(kleis.models?.["gpt-5.3-codex"]?.id).toBe("gpt-5.3-codex");
+    expect(kleis.models?.["gpt-5.3-codex-spark"]?.id).toBe(
+      "gpt-5.3-codex-spark"
+    );
     expect(kleis.models?.["openai/gpt-5.3-codex"]).toBeUndefined();
     expect(kleis.models?.["github-copilot/gpt-5"]?.id).toBe(
       "github-copilot/gpt-5"
@@ -212,7 +223,7 @@ describe("models registry contract", () => {
       models?: Record<string, { id?: string }>;
     };
     expect(openai.env).toEqual(["OPENAI_API_KEY"]);
-    expect(Object.keys(openai.models ?? {})).toHaveLength(3);
+    expect(Object.keys(openai.models ?? {})).toHaveLength(4);
 
     const kleis = registry.kleis as {
       models?: Record<string, { id?: string }>;
@@ -234,7 +245,7 @@ describe("models registry contract", () => {
       models?: Record<string, unknown>;
     };
     expect(openai.env).toEqual(["OPENAI_API_KEY"]);
-    expect(Object.keys(openai.models ?? {})).toHaveLength(3);
+    expect(Object.keys(openai.models ?? {})).toHaveLength(4);
 
     expect(registry.anthropic).toBeDefined();
     expect(registry["github-copilot"]).toBeDefined();
@@ -273,6 +284,7 @@ describe("models registry contract", () => {
     expect(openai.env).toEqual(["OPENAI_API_KEY"]);
     expect(Object.keys(openai.models ?? {})).toEqual([
       "gpt-5.3-codex",
+      "gpt-5.3-codex-spark",
       "gpt-5",
       "text-embedding-3-large",
     ]);
@@ -325,7 +337,10 @@ describe("models registry contract", () => {
     const kleis = registry.kleis as {
       models?: Record<string, unknown>;
     };
-    expect(Object.keys(kleis.models ?? {})).toEqual(["gpt-5.3-codex"]);
+    expect(Object.keys(kleis.models ?? {})).toEqual([
+      "gpt-5.3-codex",
+      "gpt-5.3-codex-spark",
+    ]);
   });
 
   test("account-scoped mode only narrows the kleis aggregate provider", () => {

--- a/tests/providers/proxy-contract.test.ts
+++ b/tests/providers/proxy-contract.test.ts
@@ -1393,6 +1393,44 @@ describe("proxy contract: codex", () => {
     expect(text).toContain("response.completed");
   });
 
+  test("keeps retrying websocket setup failures before session fallback", async () => {
+    const sentBodies: unknown[] = [];
+    const sockets = installManualCodexWebSocketMock(sentBodies, {
+      autoOpen: false,
+    });
+    const headers = new Headers({
+      authorization: "Bearer codex-access",
+      [CODEX_ACCOUNT_ID_HEADER]: "acct_1",
+      "x-session-affinity": "retry-budget-session",
+    });
+    const bodyJson = {
+      model: "gpt-5-codex",
+      stream: true,
+      input: [
+        { role: "user", content: [{ type: "input_text", text: "Retry" }] },
+      ],
+    };
+
+    for (let attempt = 0; attempt < 6; attempt++) {
+      const responsePromise = tryProxyCodexWebSocket({
+        headers,
+        bodyJson,
+        accountKey: "key-1:account-1",
+      });
+      await waitFor(() => sockets.length === attempt + 1);
+      sockets[attempt]?.dispatch("close", { code: 1006 });
+      expect(await responsePromise).toBeNull();
+    }
+
+    const fallback = await tryProxyCodexWebSocket({
+      headers,
+      bodyJson,
+      accountKey: "key-1:account-1",
+    });
+    expect(fallback).toBeNull();
+    expect(sockets).toHaveLength(6);
+  });
+
   test("treats same-session websocket connect races as busy", async () => {
     const sentBodies: unknown[] = [];
     const sockets = installManualCodexWebSocketMock(sentBodies, {

--- a/tests/providers/proxy-contract.test.ts
+++ b/tests/providers/proxy-contract.test.ts
@@ -6,6 +6,7 @@ import {
   CODEX_ACCOUNT_ID_HEADER,
   CODEX_ORIGINATOR,
   CODEX_RESPONSE_ENDPOINT,
+  CODEX_USER_AGENT,
   CODEX_WEBSOCKET_BETA_HEADER,
   COPILOT_INITIATOR_HEADER,
   COPILOT_VISION_HEADER,
@@ -291,9 +292,11 @@ describe("proxy contract: codex", () => {
 
     expect(headers.get("authorization")).toBe("Bearer codex-access");
     expect(headers.get(CODEX_ACCOUNT_ID_HEADER)).toBe("acct-meta");
+    expect(headers.get("content-type")).toBe("application/json");
     expect(headers.get("originator")).toBe(CODEX_ORIGINATOR);
+    expect(headers.get("User-Agent")).toBe(CODEX_USER_AGENT);
     expect(result.upstreamUrl).toBe(CODEX_RESPONSE_ENDPOINT);
-    expect(result.bodyText).toBe(bodyText);
+    expect(JSON.parse(result.bodyText)).toEqual({ ...bodyJson, store: false });
   });
 
   test("uses account id when metadata is absent", () => {
@@ -401,6 +404,7 @@ describe("proxy contract: codex", () => {
       instructions: "Keep responses concise",
       max_output_tokens: 4096,
       max_completion_tokens: 4096,
+      store: true,
       input: [
         {
           role: "user",
@@ -421,9 +425,11 @@ describe("proxy contract: codex", () => {
     const transformed = JSON.parse(result.bodyText) as {
       max_output_tokens?: number;
       max_completion_tokens?: number;
+      store?: boolean;
     };
     expect(transformed.max_output_tokens).toBeUndefined();
     expect(transformed.max_completion_tokens).toBeUndefined();
+    expect(transformed.store).toBe(false);
   });
 
   test("extracts normalized usage from non-streaming responses", async () => {
@@ -614,6 +620,7 @@ describe("proxy contract: codex", () => {
     const headers = new Headers({
       authorization: "Bearer codex-access",
       [CODEX_ACCOUNT_ID_HEADER]: "acct_1",
+      "content-length": "123",
       "session-id": "raw-session-id",
       "x-session-affinity": "session-1",
     });
@@ -695,6 +702,7 @@ describe("proxy contract: codex", () => {
     );
     expect(lowerHeaderEntries["openai-beta"]).toBe(CODEX_WEBSOCKET_BETA_HEADER);
     expect(lowerHeaderEntries.authorization).toBe("Bearer codex-access");
+    expect(lowerHeaderEntries["content-length"]).toBeUndefined();
     expect(lowerHeaderEntries.session_id).toBeUndefined();
     expect(lowerHeaderEntries["x-session-affinity"]).toBeUndefined();
     expect(lowerHeaderEntries["session-id"]).toMatch(/^kleis_/);
@@ -1391,6 +1399,7 @@ describe("proxy contract: codex", () => {
     expect(response).not.toBeNull();
     const text = await response?.text();
     expect(text).toContain("response.completed");
+    expect(text).toContain("data: [DONE]");
   });
 
   test("preserves websocket message order for async binary messages", async () => {
@@ -1428,6 +1437,7 @@ describe("proxy contract: codex", () => {
         response: { id: "resp_1", status: "completed" },
       }),
     });
+    sockets[0]?.dispatch("close", { code: 1000 });
 
     let response: Response | null | undefined;
     responsePromise.then((value) => {

--- a/tests/providers/proxy-contract.test.ts
+++ b/tests/providers/proxy-contract.test.ts
@@ -1353,6 +1353,46 @@ describe("proxy contract: codex", () => {
     expect(sentBodies).toHaveLength(2);
   });
 
+  test("decodes binary websocket messages", async () => {
+    const sentBodies: unknown[] = [];
+    const sockets = installManualCodexWebSocketMock(sentBodies);
+    const headers = new Headers({
+      authorization: "Bearer codex-access",
+      [CODEX_ACCOUNT_ID_HEADER]: "acct_1",
+    });
+    const encoder = new TextEncoder();
+
+    const responsePromise = tryProxyCodexWebSocket({
+      headers,
+      bodyJson: {
+        model: "gpt-5-codex",
+        stream: true,
+        input: [
+          { role: "user", content: [{ type: "input_text", text: "Binary" }] },
+        ],
+      },
+      accountKey: "key-1:account-1",
+    });
+
+    await waitFor(() => sentBodies.length === 1);
+    for (const event of [
+      { type: "response.created", response: { id: "resp_1" } },
+      {
+        type: "response.completed",
+        response: { id: "resp_1", status: "completed" },
+      },
+    ]) {
+      sockets[0]?.dispatch("message", {
+        data: encoder.encode(JSON.stringify(event)).buffer,
+      });
+    }
+
+    const response = await responsePromise;
+    expect(response).not.toBeNull();
+    const text = await response?.text();
+    expect(text).toContain("response.completed");
+  });
+
   test("treats same-session websocket connect races as busy", async () => {
     const sentBodies: unknown[] = [];
     const sockets = installManualCodexWebSocketMock(sentBodies, {

--- a/tests/providers/proxy-contract.test.ts
+++ b/tests/providers/proxy-contract.test.ts
@@ -1295,6 +1295,64 @@ describe("proxy contract: codex", () => {
     expect(thirdBody.input).toEqual(thirdInput);
   });
 
+  test("retries websocket connection limit errors before streaming output", async () => {
+    const sentBodies: unknown[] = [];
+    const sockets = installManualCodexWebSocketMock(sentBodies);
+    const headers = new Headers({
+      authorization: "Bearer codex-access",
+      [CODEX_ACCOUNT_ID_HEADER]: "acct_1",
+      "x-session-affinity": "retry-session",
+    });
+
+    const responsePromise = tryProxyCodexWebSocket({
+      headers,
+      bodyJson: {
+        model: "gpt-5-codex",
+        stream: true,
+        input: [
+          { role: "user", content: [{ type: "input_text", text: "Retry" }] },
+        ],
+      },
+      accountKey: "key-1:account-1",
+    });
+
+    await waitFor(() => sentBodies.length === 1);
+    sockets[0]?.dispatch("message", {
+      data: JSON.stringify({
+        type: "error",
+        error: { code: "websocket_connection_limit_reached" },
+      }),
+    });
+
+    await waitFor(() => sentBodies.length === 2 && sockets.length === 2);
+    sockets[1]?.dispatch("message", {
+      data: JSON.stringify({
+        type: "response.created",
+        response: { id: "resp_1" },
+      }),
+    });
+    sockets[1]?.dispatch("message", {
+      data: JSON.stringify({
+        type: "response.completed",
+        response: {
+          id: "resp_1",
+          usage: {
+            input_tokens: 10,
+            output_tokens: 2,
+            input_tokens_details: { cached_tokens: 3 },
+          },
+          status: "completed",
+        },
+      }),
+    });
+
+    const response = await responsePromise;
+    expect(response).not.toBeNull();
+    const text = await response?.text();
+    expect(text).toContain("response.completed");
+    expect(sentBodies).toHaveLength(2);
+  });
+
   test("treats same-session websocket connect races as busy", async () => {
     const sentBodies: unknown[] = [];
     const sockets = installManualCodexWebSocketMock(sentBodies, {

--- a/tests/providers/proxy-contract.test.ts
+++ b/tests/providers/proxy-contract.test.ts
@@ -1393,6 +1393,68 @@ describe("proxy contract: codex", () => {
     expect(text).toContain("response.completed");
   });
 
+  test("preserves websocket message order for async binary messages", async () => {
+    const sentBodies: unknown[] = [];
+    const sockets = installManualCodexWebSocketMock(sentBodies);
+    const headers = new Headers({
+      authorization: "Bearer codex-access",
+      [CODEX_ACCOUNT_ID_HEADER]: "acct_1",
+    });
+    const encoder = new TextEncoder();
+    let resolveBuffer: ((buffer: ArrayBuffer) => void) | null = null;
+    const delayedBuffer = new Promise<ArrayBuffer>((resolve) => {
+      resolveBuffer = resolve;
+    });
+
+    const responsePromise = tryProxyCodexWebSocket({
+      headers,
+      bodyJson: {
+        model: "gpt-5-codex",
+        stream: true,
+        input: [
+          { role: "user", content: [{ type: "input_text", text: "Order" }] },
+        ],
+      },
+      accountKey: "key-1:account-1",
+    });
+
+    await waitFor(() => sentBodies.length === 1);
+    sockets[0]?.dispatch("message", {
+      data: { arrayBuffer: () => delayedBuffer },
+    });
+    sockets[0]?.dispatch("message", {
+      data: JSON.stringify({
+        type: "response.completed",
+        response: { id: "resp_1", status: "completed" },
+      }),
+    });
+
+    let response: Response | null | undefined;
+    responsePromise.then((value) => {
+      response = value;
+    });
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    expect(response).toBeUndefined();
+
+    const createdBytes = encoder.encode(
+      JSON.stringify({ type: "response.created", response: { id: "resp_1" } })
+    );
+    resolveBuffer?.(
+      createdBytes.buffer.slice(
+        createdBytes.byteOffset,
+        createdBytes.byteOffset + createdBytes.byteLength
+      )
+    );
+    await waitFor(() => response !== undefined);
+    if (!response) {
+      throw new Error("Expected websocket response");
+    }
+    const text = await response.text();
+    expect(text.indexOf("response.created")).toBeLessThan(
+      text.indexOf("response.completed")
+    );
+  });
+
   test("keeps retrying websocket setup failures before session fallback", async () => {
     const sentBodies: unknown[] = [];
     const sockets = installManualCodexWebSocketMock(sentBodies, {


### PR DESCRIPTION
## Summary
- align Codex WebSocket retry/fallback behavior with recent OpenCode transport fixes
- adopt Pi v0.76.0 Codex transport hardening for SSE header stalls and WebSocket binary/error handling
- add proxy contract coverage for connection-limit retry and binary WebSocket messages

## Verification
- bun fix
- bun typecheck
- bun lint
- bun test