### PR TITLE
fix(models): match opencode Codex model filter

### DIFF
--- a/src/domain/models/models-dev.ts
+++ b/src/domain/models/models-dev.ts
@@ -29,19 +29,16 @@ const KLEIS_PROVIDER_NAME = "Kleis";
 const PROXY_API_KEY_ENV = "KLEIS_API_KEY";
 const MODELS_DEV_URL = "https://models.dev/api.json";
 const MODELS_DEV_CACHE_TTL_MS = 5 * 60 * 1000;
-// https://github.com/anomalyco/opencode/blob/97300085437899af8af6c2bbf6ebc6bdab110174/packages/opencode/src/plugin/codex.ts#L361
+// Match OpenCode's ChatGPT OAuth model gate.
+// https://github.com/anomalyco/opencode/blob/9976269ab1accfc9f9dc98a4a688c516934de422/packages/opencode/src/plugin/openai/codex.ts
 const CODEX_ALLOWED_OPENAI_MODEL_IDS = new Set([
-  "gpt-5.1-codex",
-  "gpt-5.1-codex-max",
-  "gpt-5.1-codex-mini",
-  "gpt-5.2",
-  "gpt-5.2-codex",
-  "gpt-5.3-codex",
   "gpt-5.3-codex-spark",
   "gpt-5.4",
   "gpt-5.4-mini",
   "gpt-5.5",
 ]);
+const CODEX_DISALLOWED_OPENAI_MODEL_IDS = new Set(["gpt-5.5-pro"]);
+const CODEX_DYNAMIC_GPT_VERSION_THRESHOLD = 5.4;
 
 const CODEX_MODEL_LIMIT_OVERRIDES: Record<string, JsonObject> = {
   // gpt-5.5 temporarily has a restricted context window for Codex plans.
@@ -166,9 +163,15 @@ const isModelSupportedByProxyProvider = (
   }
 
   const normalizedModelId = modelId.toLowerCase();
+  if (CODEX_DISALLOWED_OPENAI_MODEL_IDS.has(normalizedModelId)) {
+    return false;
+  }
+
+  const gptVersion = normalizedModelId.match(/^gpt-(\d+\.\d+)/u)?.[1];
   return (
-    normalizedModelId.includes("codex") ||
-    CODEX_ALLOWED_OPENAI_MODEL_IDS.has(normalizedModelId)
+    CODEX_ALLOWED_OPENAI_MODEL_IDS.has(normalizedModelId) ||
+    (gptVersion !== undefined &&
+      Number.parseFloat(gptVersion) > CODEX_DYNAMIC_GPT_VERSION_THRESHOLD)
   );
 };
 

--- a/tests/domain/models-dev-contract.test.ts
+++ b/tests/domain/models-dev-contract.test.ts
@@ -37,6 +37,30 @@ const upstreamRegistry = {
           npm: "@ai-sdk/openai",
         },
       },
+      "gpt-5.5-pro": {
+        id: "gpt-5.5-pro",
+        name: "GPT-5.5 Pro",
+        provider: {
+          api: "https://api.openai.com/v1",
+          npm: "@ai-sdk/openai",
+        },
+      },
+      "gpt-5.6": {
+        id: "gpt-5.6",
+        name: "GPT-5.6",
+        provider: {
+          api: "https://api.openai.com/v1",
+          npm: "@ai-sdk/openai",
+        },
+      },
+      "gpt-5.6-luna": {
+        id: "gpt-5.6-luna",
+        name: "GPT-5.6 Luna",
+        provider: {
+          api: "https://api.openai.com/v1",
+          npm: "@ai-sdk/openai",
+        },
+      },
       "gpt-5": {
         id: "gpt-5",
         name: "GPT-5",
@@ -150,11 +174,13 @@ describe("models registry contract", () => {
       models?: Record<string, { id?: string; provider?: { api?: string } }>;
     };
     expect(kleis.env).toEqual(["KLEIS_API_KEY"]);
-    expect(kleis.models?.["gpt-5.3-codex"]?.id).toBe("gpt-5.3-codex");
     expect(kleis.models?.["gpt-5.3-codex-spark"]?.id).toBe(
       "gpt-5.3-codex-spark"
     );
     expect(kleis.models?.["gpt-5.5"]?.id).toBe("gpt-5.5");
+    expect(kleis.models?.["gpt-5.5-pro"]).toBeUndefined();
+    expect(kleis.models?.["gpt-5.6"]?.id).toBe("gpt-5.6");
+    expect(kleis.models?.["gpt-5.6-luna"]?.id).toBe("gpt-5.6-luna");
     expect(kleis.models?.["openai/gpt-5.3-codex"]).toBeUndefined();
     expect(kleis.models?.["github-copilot/gpt-5"]?.id).toBe(
       "github-copilot/gpt-5"
@@ -254,12 +280,15 @@ describe("models registry contract", () => {
       models?: Record<string, { id?: string }>;
     };
     expect(openai.env).toEqual(["OPENAI_API_KEY"]);
-    expect(Object.keys(openai.models ?? {})).toHaveLength(5);
+    expect(Object.keys(openai.models ?? {})).toHaveLength(8);
 
     const kleis = registry.kleis as {
       models?: Record<string, { id?: string }>;
     };
-    expect(kleis.models?.["gpt-5.3-codex"]?.id).toBe("gpt-5.3-codex");
+    expect(kleis.models?.["gpt-5.3-codex"]).toBeUndefined();
+    expect(kleis.models?.["gpt-5.3-codex-spark"]?.id).toBe(
+      "gpt-5.3-codex-spark"
+    );
     expect(kleis.models?.["anthropic/claude-sonnet-4"]).toBeUndefined();
     expect(kleis.models?.["github-copilot/gpt-5"]).toBeUndefined();
   });
@@ -276,7 +305,7 @@ describe("models registry contract", () => {
       models?: Record<string, unknown>;
     };
     expect(openai.env).toEqual(["OPENAI_API_KEY"]);
-    expect(Object.keys(openai.models ?? {})).toHaveLength(5);
+    expect(Object.keys(openai.models ?? {})).toHaveLength(8);
 
     expect(registry.anthropic).toBeDefined();
     expect(registry["github-copilot"]).toBeDefined();
@@ -296,7 +325,7 @@ describe("models registry contract", () => {
       configuredProviders: ["codex", "claude", "copilot"],
       apiKeyScopes: {
         providerScopes: ["codex", "copilot"],
-        modelScopes: ["openai/gpt-5.3-codex", "gpt-5-mini"],
+        modelScopes: ["openai/gpt-5.6", "gpt-5-mini"],
         accountProviderScopes: null,
       },
     });
@@ -317,6 +346,9 @@ describe("models registry contract", () => {
       "gpt-5.3-codex",
       "gpt-5.3-codex-spark",
       "gpt-5.5",
+      "gpt-5.5-pro",
+      "gpt-5.6",
+      "gpt-5.6-luna",
       "gpt-5",
       "text-embedding-3-large",
     ]);
@@ -334,7 +366,7 @@ describe("models registry contract", () => {
     };
     expect(Object.keys(kleis.models ?? {}).sort()).toEqual([
       "github-copilot/gpt-5-mini",
-      "gpt-5.3-codex",
+      "gpt-5.6",
     ]);
   });
 
@@ -370,9 +402,10 @@ describe("models registry contract", () => {
       models?: Record<string, unknown>;
     };
     expect(Object.keys(kleis.models ?? {})).toEqual([
-      "gpt-5.3-codex",
       "gpt-5.3-codex-spark",
       "gpt-5.5",
+      "gpt-5.6",
+      "gpt-5.6-luna",
     ]);
   });
 


### PR DESCRIPTION
## Summary
- Match the Codex/ChatGPT OAuth model filtering behavior from opencode dev, pinned to commit 9976269ab1accfc9f9dc98a4a688c516934de422
- Add dynamic inclusion for GPT model versions greater than 5.4, including current gpt-5.6 variants
- Explicitly exclude gpt-5.5-pro and update model registry contract coverage

## Tests
- bun test
- bun typecheck
- bun lint