### PR TITLE
fix: harden stream transport reliability

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -5,7 +5,3 @@ TURSO_AUTH_TOKEN=<your-turso-token>
 
 # Optional: local server port. Defaults to 3003.
 PORT=3003
-
-# Optional: bypass Codex WebSocket for larger request frames. Defaults to 8 MiB.
-# Set to 0 to disable the size guard.
-CODEX_WEBSOCKET_MAX_REQUEST_BYTES=8388608

--- a/.env.example
+++ b/.env.example
@@ -5,3 +5,7 @@ TURSO_AUTH_TOKEN=<your-turso-token>
 
 # Optional: local server port. Defaults to 3003.
 PORT=3003
+
+# Optional: bypass Codex WebSocket for larger request frames. Defaults to 8 MiB.
+# Set to 0 to disable the size guard.
+CODEX_WEBSOCKET_MAX_REQUEST_BYTES=8388608

--- a/bun.lock
+++ b/bun.lock
@@ -9,11 +9,13 @@
         "@libsql/client": "^0.15.15",
         "drizzle-orm": "^0.45.1",
         "hono": "^4.12.2",
+        "ws": "8.21.0",
         "zod": "^4.3.6",
       },
       "devDependencies": {
         "@biomejs/biome": "2.4.0",
         "@types/bun": "^1.3.9",
+        "@types/ws": "8.18.1",
         "@typescript/native-preview": "^7.0.0-dev.20260223.1",
         "drizzle-kit": "^0.31.9",
         "lefthook": "^2.1.1",
@@ -262,11 +264,13 @@
 
     "web-streams-polyfill": ["web-streams-polyfill@3.3.3", "", {}, "sha512-d2JWLCivmZYTSIoge9MsgFCZrt571BikcWGYkjC1khllbTeDlGqZ2D8vD8E/lJa8WGWbb7Plm8/XJYV7IJHZZw=="],
 
-    "ws": ["ws@8.18.0", "", { "peerDependencies": { "bufferutil": "^4.0.1", "utf-8-validate": ">=5.0.2" }, "optionalPeers": ["bufferutil", "utf-8-validate"] }, "sha512-8VbfWfHLbbwu3+N6OKsOMpBdT4kXPDDB9cJk2bJ6mh9ucxdlnNvH1e+roYkKmN9Nxw2yjz7VzeO9oOz2zJ04Pw=="],
+    "ws": ["ws@8.21.0", "", { "peerDependencies": { "bufferutil": "^4.0.1", "utf-8-validate": ">=5.0.2" }, "optionalPeers": ["bufferutil", "utf-8-validate"] }, "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g=="],
 
     "zod": ["zod@4.3.6", "", {}, "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg=="],
 
     "@esbuild-kit/core-utils/esbuild": ["esbuild@0.18.20", "", { "optionalDependencies": { "@esbuild/android-arm": "0.18.20", "@esbuild/android-arm64": "0.18.20", "@esbuild/android-x64": "0.18.20", "@esbuild/darwin-arm64": "0.18.20", "@esbuild/darwin-x64": "0.18.20", "@esbuild/freebsd-arm64": "0.18.20", "@esbuild/freebsd-x64": "0.18.20", "@esbuild/linux-arm": "0.18.20", "@esbuild/linux-arm64": "0.18.20", "@esbuild/linux-ia32": "0.18.20", "@esbuild/linux-loong64": "0.18.20", "@esbuild/linux-mips64el": "0.18.20", "@esbuild/linux-ppc64": "0.18.20", "@esbuild/linux-riscv64": "0.18.20", "@esbuild/linux-s390x": "0.18.20", "@esbuild/linux-x64": "0.18.20", "@esbuild/netbsd-x64": "0.18.20", "@esbuild/openbsd-x64": "0.18.20", "@esbuild/sunos-x64": "0.18.20", "@esbuild/win32-arm64": "0.18.20", "@esbuild/win32-ia32": "0.18.20", "@esbuild/win32-x64": "0.18.20" }, "bin": { "esbuild": "bin/esbuild" } }, "sha512-ceqxoedUrcayh7Y7ZX6NdbbDzGROiyVBgC4PriJThBKSVPWnnFHZAkfI1lJT8QFkOwH4qOS2SJkS4wvpGl8BpA=="],
+
+    "@libsql/isomorphic-ws/ws": ["ws@8.18.0", "", { "peerDependencies": { "bufferutil": "^4.0.1", "utf-8-validate": ">=5.0.2" }, "optionalPeers": ["bufferutil", "utf-8-validate"] }, "sha512-8VbfWfHLbbwu3+N6OKsOMpBdT4kXPDDB9cJk2bJ6mh9ucxdlnNvH1e+roYkKmN9Nxw2yjz7VzeO9oOz2zJ04Pw=="],
 
     "@esbuild-kit/core-utils/esbuild/@esbuild/android-arm": ["@esbuild/android-arm@0.18.20", "", { "os": "android", "cpu": "arm" }, "sha512-fyi7TDI/ijKKNZTUJAQqiG5T7YjJXgnzkURqmGj13C6dCqckZBLdl4h7bkhHt/t0WP+zO9/zwroDvANaOqO5Sw=="],
 

--- a/bun.lock
+++ b/bun.lock
@@ -9,12 +9,15 @@
         "@libsql/client": "^0.15.15",
         "drizzle-orm": "^0.45.1",
         "hono": "^4.12.2",
+        "https-proxy-agent": "7.0.6",
+        "proxy-from-env": "1.1.0",
         "ws": "8.21.0",
         "zod": "^4.3.6",
       },
       "devDependencies": {
         "@biomejs/biome": "2.4.0",
         "@types/bun": "^1.3.9",
+        "@types/proxy-from-env": "^1.0.4",
         "@types/ws": "8.18.1",
         "@typescript/native-preview": "^7.0.0-dev.20260223.1",
         "drizzle-kit": "^0.31.9",
@@ -142,6 +145,8 @@
 
     "@types/node": ["@types/node@25.3.0", "", { "dependencies": { "undici-types": "~7.18.0" } }, "sha512-4K3bqJpXpqfg2XKGK9bpDTc6xO/xoUP/RBWS7AtRMug6zZFaRekiLzjVtAoZMquxoAbzBvy5nxQ7veS5eYzf8A=="],
 
+    "@types/proxy-from-env": ["@types/proxy-from-env@1.0.4", "", { "dependencies": { "@types/node": "*" } }, "sha512-TPR9/bCZAr3V1eHN4G3LD3OLicdJjqX1QRXWuNcCYgE66f/K8jO2ZRtHxI2D9MbnuUP6+qiKSS8eUHp6TFHGCw=="],
+
     "@types/ws": ["@types/ws@8.18.1", "", { "dependencies": { "@types/node": "*" } }, "sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg=="],
 
     "@typescript/native-preview": ["@typescript/native-preview@7.0.0-dev.20260223.1", "", { "optionalDependencies": { "@typescript/native-preview-darwin-arm64": "7.0.0-dev.20260223.1", "@typescript/native-preview-darwin-x64": "7.0.0-dev.20260223.1", "@typescript/native-preview-linux-arm": "7.0.0-dev.20260223.1", "@typescript/native-preview-linux-arm64": "7.0.0-dev.20260223.1", "@typescript/native-preview-linux-x64": "7.0.0-dev.20260223.1", "@typescript/native-preview-win32-arm64": "7.0.0-dev.20260223.1", "@typescript/native-preview-win32-x64": "7.0.0-dev.20260223.1" }, "bin": { "tsgo": "bin/tsgo.js" } }, "sha512-NEifR9F/0khbTQRztM4Yuxcj9dFuK9ubWIXJwLSmKMlncSp4u1fzRnlfv1vlNKKrXB7BUXoANFHpsM5BEXJ06w=="],
@@ -159,6 +164,8 @@
     "@typescript/native-preview-win32-arm64": ["@typescript/native-preview-win32-arm64@7.0.0-dev.20260223.1", "", { "os": "win32", "cpu": "arm64" }, "sha512-HHu63F8cDhgIlqFGBnqBVQn7HSiORxyT0M6yPzG4tG4gdzx+aFUdogbYily0nzN5b6NolQTrFfh3Q85UfHCHqg=="],
 
     "@typescript/native-preview-win32-x64": ["@typescript/native-preview-win32-x64@7.0.0-dev.20260223.1", "", { "os": "win32", "cpu": "x64" }, "sha512-vSis36O5qT+vOYfei7GtfWWzvIoaNdmxa1zDypBKkGGCCHt/c5vp0pXls85+8jBVS11Ep6p7ECcHlt+R5CBaug=="],
+
+    "agent-base": ["agent-base@7.1.4", "", {}, "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ=="],
 
     "balanced-match": ["balanced-match@4.0.4", "", {}, "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA=="],
 
@@ -197,6 +204,8 @@
     "glob": ["glob@13.0.6", "", { "dependencies": { "minimatch": "^10.2.2", "minipass": "^7.1.3", "path-scurry": "^2.0.2" } }, "sha512-Wjlyrolmm8uDpm/ogGyXZXb1Z+Ca2B8NbJwqBVg0axK9GbBeoS7yGV6vjXnYdGm6X53iehEuxxbyiKp8QmN4Vw=="],
 
     "hono": ["hono@4.12.2", "", {}, "sha512-gJnaDHXKDayjt8ue0n8Gs0A007yKXj4Xzb8+cNjZeYsSzzwKc0Lr+OZgYwVfB0pHfUs17EPoLvrOsEaJ9mj+Tg=="],
+
+    "https-proxy-agent": ["https-proxy-agent@7.0.6", "", { "dependencies": { "agent-base": "^7.1.2", "debug": "4" } }, "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw=="],
 
     "js-base64": ["js-base64@3.7.8", "", {}, "sha512-hNngCeKxIUQiEUN3GPJOkz4wF/YvdUdbNL9hsBcMQTkKzboD7T/q3OYOuuPZLUE6dBxSGpwhk5mwuDud7JVAow=="],
 
@@ -247,6 +256,8 @@
     "picocolors": ["picocolors@1.1.1", "", {}, "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA=="],
 
     "promise-limit": ["promise-limit@2.7.0", "", {}, "sha512-7nJ6v5lnJsXwGprnGXga4wx6d1POjvi5Qmf1ivTRxTjH4Z/9Czja/UCMLVmB9N93GeWOU93XaFaEt6jbuoagNw=="],
+
+    "proxy-from-env": ["proxy-from-env@1.1.0", "", {}, "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg=="],
 
     "resolve-pkg-maps": ["resolve-pkg-maps@1.0.0", "", {}, "sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw=="],
 

--- a/bun.lock
+++ b/bun.lock
@@ -9,15 +9,12 @@
         "@libsql/client": "^0.15.15",
         "drizzle-orm": "^0.45.1",
         "hono": "^4.12.2",
-        "https-proxy-agent": "7.0.6",
-        "proxy-from-env": "1.1.0",
         "ws": "8.21.0",
         "zod": "^4.3.6",
       },
       "devDependencies": {
         "@biomejs/biome": "2.4.0",
         "@types/bun": "^1.3.9",
-        "@types/proxy-from-env": "^1.0.4",
         "@types/ws": "8.18.1",
         "@typescript/native-preview": "^7.0.0-dev.20260223.1",
         "drizzle-kit": "^0.31.9",
@@ -145,8 +142,6 @@
 
     "@types/node": ["@types/node@25.3.0", "", { "dependencies": { "undici-types": "~7.18.0" } }, "sha512-4K3bqJpXpqfg2XKGK9bpDTc6xO/xoUP/RBWS7AtRMug6zZFaRekiLzjVtAoZMquxoAbzBvy5nxQ7veS5eYzf8A=="],
 
-    "@types/proxy-from-env": ["@types/proxy-from-env@1.0.4", "", { "dependencies": { "@types/node": "*" } }, "sha512-TPR9/bCZAr3V1eHN4G3LD3OLicdJjqX1QRXWuNcCYgE66f/K8jO2ZRtHxI2D9MbnuUP6+qiKSS8eUHp6TFHGCw=="],
-
     "@types/ws": ["@types/ws@8.18.1", "", { "dependencies": { "@types/node": "*" } }, "sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg=="],
 
     "@typescript/native-preview": ["@typescript/native-preview@7.0.0-dev.20260223.1", "", { "optionalDependencies": { "@typescript/native-preview-darwin-arm64": "7.0.0-dev.20260223.1", "@typescript/native-preview-darwin-x64": "7.0.0-dev.20260223.1", "@typescript/native-preview-linux-arm": "7.0.0-dev.20260223.1", "@typescript/native-preview-linux-arm64": "7.0.0-dev.20260223.1", "@typescript/native-preview-linux-x64": "7.0.0-dev.20260223.1", "@typescript/native-preview-win32-arm64": "7.0.0-dev.20260223.1", "@typescript/native-preview-win32-x64": "7.0.0-dev.20260223.1" }, "bin": { "tsgo": "bin/tsgo.js" } }, "sha512-NEifR9F/0khbTQRztM4Yuxcj9dFuK9ubWIXJwLSmKMlncSp4u1fzRnlfv1vlNKKrXB7BUXoANFHpsM5BEXJ06w=="],
@@ -164,8 +159,6 @@
     "@typescript/native-preview-win32-arm64": ["@typescript/native-preview-win32-arm64@7.0.0-dev.20260223.1", "", { "os": "win32", "cpu": "arm64" }, "sha512-HHu63F8cDhgIlqFGBnqBVQn7HSiORxyT0M6yPzG4tG4gdzx+aFUdogbYily0nzN5b6NolQTrFfh3Q85UfHCHqg=="],
 
     "@typescript/native-preview-win32-x64": ["@typescript/native-preview-win32-x64@7.0.0-dev.20260223.1", "", { "os": "win32", "cpu": "x64" }, "sha512-vSis36O5qT+vOYfei7GtfWWzvIoaNdmxa1zDypBKkGGCCHt/c5vp0pXls85+8jBVS11Ep6p7ECcHlt+R5CBaug=="],
-
-    "agent-base": ["agent-base@7.1.4", "", {}, "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ=="],
 
     "balanced-match": ["balanced-match@4.0.4", "", {}, "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA=="],
 
@@ -204,8 +197,6 @@
     "glob": ["glob@13.0.6", "", { "dependencies": { "minimatch": "^10.2.2", "minipass": "^7.1.3", "path-scurry": "^2.0.2" } }, "sha512-Wjlyrolmm8uDpm/ogGyXZXb1Z+Ca2B8NbJwqBVg0axK9GbBeoS7yGV6vjXnYdGm6X53iehEuxxbyiKp8QmN4Vw=="],
 
     "hono": ["hono@4.12.2", "", {}, "sha512-gJnaDHXKDayjt8ue0n8Gs0A007yKXj4Xzb8+cNjZeYsSzzwKc0Lr+OZgYwVfB0pHfUs17EPoLvrOsEaJ9mj+Tg=="],
-
-    "https-proxy-agent": ["https-proxy-agent@7.0.6", "", { "dependencies": { "agent-base": "^7.1.2", "debug": "4" } }, "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw=="],
 
     "js-base64": ["js-base64@3.7.8", "", {}, "sha512-hNngCeKxIUQiEUN3GPJOkz4wF/YvdUdbNL9hsBcMQTkKzboD7T/q3OYOuuPZLUE6dBxSGpwhk5mwuDud7JVAow=="],
 
@@ -256,8 +247,6 @@
     "picocolors": ["picocolors@1.1.1", "", {}, "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA=="],
 
     "promise-limit": ["promise-limit@2.7.0", "", {}, "sha512-7nJ6v5lnJsXwGprnGXga4wx6d1POjvi5Qmf1ivTRxTjH4Z/9Czja/UCMLVmB9N93GeWOU93XaFaEt6jbuoagNw=="],
-
-    "proxy-from-env": ["proxy-from-env@1.1.0", "", {}, "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg=="],
 
     "resolve-pkg-maps": ["resolve-pkg-maps@1.0.0", "", {}, "sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw=="],
 

--- a/package.json
+++ b/package.json
@@ -20,12 +20,15 @@
     "@libsql/client": "^0.15.15",
     "drizzle-orm": "^0.45.1",
     "hono": "^4.12.2",
+    "https-proxy-agent": "7.0.6",
+    "proxy-from-env": "1.1.0",
     "ws": "8.21.0",
     "zod": "^4.3.6"
   },
   "devDependencies": {
     "@biomejs/biome": "2.4.0",
     "@types/bun": "^1.3.9",
+    "@types/proxy-from-env": "^1.0.4",
     "@types/ws": "8.18.1",
     "@typescript/native-preview": "^7.0.0-dev.20260223.1",
     "drizzle-kit": "^0.31.9",

--- a/package.json
+++ b/package.json
@@ -20,15 +20,12 @@
     "@libsql/client": "^0.15.15",
     "drizzle-orm": "^0.45.1",
     "hono": "^4.12.2",
-    "https-proxy-agent": "7.0.6",
-    "proxy-from-env": "1.1.0",
     "ws": "8.21.0",
     "zod": "^4.3.6"
   },
   "devDependencies": {
     "@biomejs/biome": "2.4.0",
     "@types/bun": "^1.3.9",
-    "@types/proxy-from-env": "^1.0.4",
     "@types/ws": "8.18.1",
     "@typescript/native-preview": "^7.0.0-dev.20260223.1",
     "drizzle-kit": "^0.31.9",

--- a/package.json
+++ b/package.json
@@ -20,11 +20,13 @@
     "@libsql/client": "^0.15.15",
     "drizzle-orm": "^0.45.1",
     "hono": "^4.12.2",
+    "ws": "8.21.0",
     "zod": "^4.3.6"
   },
   "devDependencies": {
     "@biomejs/biome": "2.4.0",
     "@types/bun": "^1.3.9",
+    "@types/ws": "8.18.1",
     "@typescript/native-preview": "^7.0.0-dev.20260223.1",
     "drizzle-kit": "^0.31.9",
     "lefthook": "^2.1.1",

--- a/src/http/routes/proxy.ts
+++ b/src/http/routes/proxy.ts
@@ -369,15 +369,17 @@ const proxyRequest = async (
       headerTimeout?.clear();
     }
   } catch (error) {
-    if (!context.req.raw.signal.aborted) {
-      logWarn("proxy_upstream_request_failed", {
-        provider: route.provider,
-        endpoint: route.endpoint,
-        elapsedMs: Date.now() - startedAt,
-        aborted: false,
-        ...errorLogFields(error),
-      });
+    if (context.req.raw.signal.aborted) {
+      // Client disconnects are expected cancellations, not proxy failures.
+      throw error;
     }
+    logWarn("proxy_upstream_request_failed", {
+      provider: route.provider,
+      endpoint: route.endpoint,
+      elapsedMs: Date.now() - startedAt,
+      aborted: false,
+      ...errorLogFields(error),
+    });
     usageRecorder.recordImmediate(500);
     throw error;
   }

--- a/src/http/routes/proxy.ts
+++ b/src/http/routes/proxy.ts
@@ -350,6 +350,7 @@ const proxyRequest = async (
       body: requestBody,
       // Provider streams can pause for minutes while a model is thinking.
       timeout: false,
+      signal: context.req.raw.signal,
     };
     if (headerTimeout) {
       upstreamRequestInit.signal = AbortSignal.any([

--- a/src/http/routes/proxy.ts
+++ b/src/http/routes/proxy.ts
@@ -369,13 +369,15 @@ const proxyRequest = async (
       headerTimeout?.clear();
     }
   } catch (error) {
-    logWarn("proxy_upstream_request_failed", {
-      provider: route.provider,
-      endpoint: route.endpoint,
-      elapsedMs: Date.now() - startedAt,
-      aborted: context.req.raw.signal.aborted,
-      ...errorLogFields(error),
-    });
+    if (!context.req.raw.signal.aborted) {
+      logWarn("proxy_upstream_request_failed", {
+        provider: route.provider,
+        endpoint: route.endpoint,
+        elapsedMs: Date.now() - startedAt,
+        aborted: false,
+        ...errorLogFields(error),
+      });
+    }
     usageRecorder.recordImmediate(500);
     throw error;
   }

--- a/src/providers/proxies/claude-proxy.ts
+++ b/src/providers/proxies/claude-proxy.ts
@@ -457,87 +457,79 @@ const maybeTransformClaudeStreamResponse = (
 
   const stream = new ReadableStream<Uint8Array>({
     start(controller): void {
-      const keepAlive = createSseKeepAlive(controller, {
+      clearKeepAlive = createSseKeepAlive(controller, {
         provider: "claude",
         transport: "sse_transform",
         getElapsedMs: () => Date.now() - startedAt,
-      });
-      clearKeepAlive = keepAlive.clear;
-
-      const pump = async (): Promise<void> => {
-        try {
-          while (true) {
-            const { done, value } = await reader.read();
-            if (done) {
-              if (closed) {
-                clearKeepAlive?.();
-                return;
-              }
-              buffer += decoder.decode();
-              if (buffer) {
-                controller.enqueue(
-                  encoder.encode(
-                    transformSseEventChunk(
-                      buffer,
-                      toolPrefix,
-                      readStreamUsage,
-                      readStreamAnomaly
-                    )
-                  )
-                );
-                buffer = "";
-              }
-              onTokenUsage?.(streamUsage);
-              closed = true;
+      }).clear;
+    },
+    async pull(controller): Promise<void> {
+      try {
+        while (true) {
+          const { done, value } = await reader.read();
+          if (done) {
+            if (closed) {
               clearKeepAlive?.();
-              controller.close();
               return;
             }
-
-            if (!value) {
-              continue;
-            }
-
-            bytes += value.byteLength;
-            chunks++;
-            lastChunkAt = Date.now();
-            buffer += decoder.decode(value, { stream: true });
-
-            let boundary = findSseEventBoundary(buffer);
-            while (boundary) {
-              const chunk = buffer.slice(0, boundary.index + boundary.length);
-              buffer = buffer.slice(boundary.index + boundary.length);
-              try {
-                controller.enqueue(
-                  encoder.encode(
-                    transformSseEventChunk(
-                      chunk,
-                      toolPrefix,
-                      readStreamUsage,
-                      readStreamAnomaly
-                    )
+            buffer += decoder.decode();
+            if (buffer) {
+              controller.enqueue(
+                encoder.encode(
+                  transformSseEventChunk(
+                    buffer,
+                    toolPrefix,
+                    readStreamUsage,
+                    readStreamAnomaly
                   )
-                );
-              } catch (error) {
-                logStreamAnomaly("claude_sse_enqueue_failed", {}, error);
-                throw error;
-              }
-              boundary = findSseEventBoundary(buffer);
+                )
+              );
+              buffer = "";
             }
-          }
-        } catch (error) {
-          if (closed) {
+            onTokenUsage?.(streamUsage);
+            closed = true;
             clearKeepAlive?.();
+            controller.close();
             return;
           }
-          closed = true;
-          clearKeepAlive?.();
-          logStreamAnomaly("claude_sse_stream_failed", {}, error);
-          controller.error(error);
-        }
-      };
 
-      pump().catch((error: unknown) => {
+          if (!value) {
+            continue;
+          }
+
+          bytes += value.byteLength;
+          chunks++;
+          lastChunkAt = Date.now();
+          buffer += decoder.decode(value, { stream: true });
+
+          let enqueued = false;
+          let boundary = findSseEventBoundary(buffer);
+          while (boundary) {
+            const chunk = buffer.slice(0, boundary.index + boundary.length);
+            buffer = buffer.slice(boundary.index + boundary.length);
+            try {
+              controller.enqueue(
+                encoder.encode(
+                  transformSseEventChunk(
+                    chunk,
+                    toolPrefix,
+                    readStreamUsage,
+                    readStreamAnomaly
+                  )
+                )
+              );
+              enqueued = true;
+            } catch (error) {
+              logStreamAnomaly("claude_sse_enqueue_failed", {}, error);
+              throw error;
+            }
+            boundary = findSseEventBoundary(buffer);
+          }
+          if (enqueued) {
+            return;
+          }
+        }
+      } catch (error) {
         if (closed) {
           clearKeepAlive?.();
           return;
@@ -546,7 +538,7 @@ const maybeTransformClaudeStreamResponse = (
         clearKeepAlive?.();
         logStreamAnomaly("claude_sse_stream_failed", {}, error);
         controller.error(error);
-      });
+      }
     },
     cancel(reason): Promise<void> {
       if (!closed) {

--- a/src/providers/proxies/claude-proxy.ts
+++ b/src/providers/proxies/claude-proxy.ts
@@ -332,6 +332,7 @@ const maybeTransformClaudeStreamResponse = (
   let bytes = 0;
   let chunks = 0;
   let lastChunkAt = startedAt;
+  let lastWriteAt = startedAt;
   let closed = false;
   let clearKeepAlive: (() => void) | null = null;
 
@@ -345,6 +346,7 @@ const maybeTransformClaudeStreamResponse = (
       transport: "sse_transform",
       elapsedMs: Date.now() - startedAt,
       idleMs: Date.now() - lastChunkAt,
+      downstreamIdleMs: Date.now() - lastWriteAt,
       bytes,
       chunks,
       ...fields,
@@ -461,6 +463,9 @@ const maybeTransformClaudeStreamResponse = (
         provider: "claude",
         transport: "sse_transform",
         getElapsedMs: () => Date.now() - startedAt,
+        onKeepAlive: () => {
+          lastWriteAt = Date.now();
+        },
       }).clear;
     },
     async pull(controller): Promise<void> {
@@ -484,6 +489,7 @@ const maybeTransformClaudeStreamResponse = (
                   )
                 )
               );
+              lastWriteAt = Date.now();
               buffer = "";
             }
             onTokenUsage?.(streamUsage);
@@ -518,6 +524,7 @@ const maybeTransformClaudeStreamResponse = (
                   )
                 )
               );
+              lastWriteAt = Date.now();
               enqueued = true;
             } catch (error) {
               logStreamAnomaly("claude_sse_enqueue_failed", {}, error);
@@ -541,9 +548,6 @@ const maybeTransformClaudeStreamResponse = (
       }
     },
     cancel(reason): Promise<void> {
-      if (!closed) {
-        logStreamAnomaly("claude_sse_downstream_cancelled", {}, reason);
-      }
       closed = true;
       clearKeepAlive?.();
       return reader.cancel(reason);

--- a/src/providers/proxies/claude-proxy.ts
+++ b/src/providers/proxies/claude-proxy.ts
@@ -15,7 +15,7 @@ import {
 } from "../../usage/token-usage";
 import { errorLogFields, logWarn } from "../../utils/log";
 import { isObjectRecord, type JsonObject } from "../../utils/object";
-import { createSseKeepAlive } from "./sse-keepalive";
+import { createSseKeepAlive, createSseResponseHeaders } from "./sse-keepalive";
 
 // Anthropic OAuth sessions reject the feedback repo path used in OpenCode's
 // prompt URL and the opening `<directories>` wrapper emitted by OpenCode's
@@ -561,7 +561,7 @@ const maybeTransformClaudeStreamResponse = (
   return new Response(stream, {
     status: response.status,
     statusText: response.statusText,
-    headers: response.headers,
+    headers: createSseResponseHeaders(response.headers),
   });
 };
 

--- a/src/providers/proxies/codex-websocket.ts
+++ b/src/providers/proxies/codex-websocket.ts
@@ -1,3 +1,5 @@
+import WebSocket from "ws";
+
 import {
   CODEX_RESPONSE_ENDPOINT,
   CODEX_WEBSOCKET_BETA_HEADER,
@@ -41,6 +43,14 @@ type WebSocketConstructor = new (
   url: string,
   protocols?: string | string[] | { headers?: Record<string, string> }
 ) => WebSocketLike;
+
+let webSocketConstructorOverride: WebSocketConstructor | null = null;
+
+export const setCodexWebSocketConstructorForTests = (
+  webSocketConstructor: WebSocketConstructor | null
+): void => {
+  webSocketConstructorOverride = webSocketConstructor;
+};
 
 type WebSocketCloseError = Error & {
   webSocketCloseCode?: number;
@@ -253,10 +263,10 @@ const scheduleExpiry = (key: string, cached: CachedSocket): void => {
 };
 
 const getWebSocketConstructor = (): WebSocketConstructor | null => {
-  const websocket = globalThis.WebSocket;
-  return typeof websocket === "function"
-    ? (websocket as unknown as WebSocketConstructor)
-    : null;
+  if (webSocketConstructorOverride) {
+    return webSocketConstructorOverride;
+  }
+  return WebSocket as unknown as WebSocketConstructor;
 };
 
 const connectWebSocket = (

--- a/src/providers/proxies/codex-websocket.ts
+++ b/src/providers/proxies/codex-websocket.ts
@@ -1,5 +1,3 @@
-import { HttpsProxyAgent } from "https-proxy-agent";
-import { getProxyForUrl } from "proxy-from-env";
 import WebSocket from "ws";
 
 import {
@@ -45,7 +43,7 @@ type WebSocketLike = {
 
 type WebSocketConstructor = new (
   url: string,
-  options?: { headers?: Record<string, string>; agent?: unknown }
+  options?: { headers?: Record<string, string> }
 ) => WebSocketLike;
 
 let webSocketConstructorOverride: WebSocketConstructor | null = null;
@@ -352,13 +350,8 @@ const connectWebSocket = (
     };
 
     try {
-      const webSocketUrl = resolveCodexWebSocketUrl();
-      const proxyUrl = getProxyForUrl(
-        webSocketUrl.replace(/^wss:/u, "https:").replace(/^ws:/u, "http:")
-      );
-      socket = new WebSocketCtor(webSocketUrl, {
+      socket = new WebSocketCtor(resolveCodexWebSocketUrl(), {
         headers: headersToRecord(headers),
-        ...(proxyUrl ? { agent: new HttpsProxyAgent(proxyUrl) } : {}),
       });
     } catch (error) {
       reject(error instanceof Error ? error : new Error(String(error)));

--- a/src/providers/proxies/codex-websocket.ts
+++ b/src/providers/proxies/codex-websocket.ts
@@ -900,6 +900,7 @@ export const tryProxyCodexWebSocket = async (
   let payloadCount = 0;
   let lastUpstreamEventAt = startedAt;
   let lastDownstreamWriteAt = startedAt;
+  let socketEpoch = 0;
   let messageChain = Promise.resolve();
   let wake: (() => void) | null = null;
   const queue: Record<string, unknown>[] = [];
@@ -983,8 +984,11 @@ export const tryProxyCodexWebSocket = async (
     }
     try {
       resetResponseIdleTimer("idle_timeout_sending_websocket_request");
-      active.socket.send(requestPayloadText, (error?: Error) => {
-        if (settled) {
+      const sendingSocket = active.socket;
+      sendingSocket.send(requestPayloadText, (error?: Error) => {
+        // Terminated sockets flush pending send callbacks with an error;
+        // ignore callbacks from sockets replaced by a connection retry.
+        if (settled || sendingSocket !== active.socket) {
           return;
         }
         if (error) {
@@ -1012,6 +1016,9 @@ export const tryProxyCodexWebSocket = async (
 
     connectionLimitAttempts++;
     retryingConnectionLimit = true;
+    // Invalidate events already dispatched (or still queued) from the socket
+    // being replaced; they must not fail the retried stream.
+    socketEpoch++;
     clearResponseIdleTimer();
     active.socket.removeEventListener("message", onMessage);
     active.socket.removeEventListener("error", onError);
@@ -1020,6 +1027,12 @@ export const tryProxyCodexWebSocket = async (
 
     try {
       const nextSocket = await connectWebSocket(headers, input.signal);
+      if (settled) {
+        // A downstream cancel or abort raced the retry; do not leak the
+        // freshly opened socket.
+        terminateSocket(nextSocket);
+        return;
+      }
       active.socket = nextSocket;
       if (active.cached) {
         active.cached.socket = nextSocket;
@@ -1101,13 +1114,30 @@ export const tryProxyCodexWebSocket = async (
   const onAbort = (): void =>
     fail("request_aborted", new Error("Request was aborted"));
 
-  const onError = (event: unknown): void =>
-    fail("socket_error", extractWebSocketError(event));
-
-  const onClose = (event: unknown): void => {
+  const onError = (event: unknown): void => {
+    const eventEpoch = socketEpoch;
+    // Serialize behind in-flight message handling so an error event cannot
+    // clobber a terminal payload that is still being processed.
     messageChain = messageChain
       .then(() => {
-        if (terminal) {
+        if (terminal || eventEpoch !== socketEpoch) {
+          wakePull();
+          return;
+        }
+        fail("socket_error", extractWebSocketError(event));
+      })
+      .catch((error: unknown) => {
+        fail("message_parse_failed", error);
+      });
+  };
+
+  const onClose = (event: unknown): void => {
+    const eventEpoch = socketEpoch;
+    messageChain = messageChain
+      .then(() => {
+        if (terminal || eventEpoch !== socketEpoch) {
+          // A close from a socket replaced by a connection-limit retry must
+          // not fail the stream or mark session fallback.
           wakePull();
           return;
         }

--- a/src/providers/proxies/codex-websocket.ts
+++ b/src/providers/proxies/codex-websocket.ts
@@ -21,7 +21,6 @@ const CONNECTION_LIMIT_RETRIES = 5;
 const STREAM_FAILURE_RETRIES = 5;
 const CONNECTION_LIMIT_REACHED_CODE = "websocket_connection_limit_reached";
 const WEBSOCKET_MESSAGE_TOO_BIG_CLOSE_CODE = 1009;
-const DEFAULT_MAX_WEBSOCKET_REQUEST_BYTES = 8 * 1024 * 1024;
 const textEncoder = new TextEncoder();
 
 type WebSocketEventType = "open" | "message" | "error" | "close";
@@ -55,7 +54,6 @@ type CodexWebSocketInput = {
   upstreamSessionId?: string | null;
   onTokenUsage?: ((usage: TokenUsage) => void) | null;
   signal?: AbortSignal;
-  maxRequestBytes?: number;
 };
 
 type ContinuationState = {
@@ -105,14 +103,6 @@ const readString = (value: unknown): string | null => {
 
   const trimmed = value.trim();
   return trimmed || null;
-};
-
-const resolveMaxRequestBytes = (): number => {
-  const configured = Number(process.env.CODEX_WEBSOCKET_MAX_REQUEST_BYTES);
-  if (Number.isFinite(configured) && configured >= 0) {
-    return configured === 0 ? Number.POSITIVE_INFINITY : configured;
-  }
-  return DEFAULT_MAX_WEBSOCKET_REQUEST_BYTES;
 };
 
 const isCompactionRequest = (
@@ -842,6 +832,7 @@ export const tryProxyCodexWebSocket = async (
   );
   let requestBody: Record<string, unknown>;
   let requestPayloadText: string;
+  let requestBytes: number;
   try {
     acquired = await acquireSocket(headers, cacheKey, input.signal);
     requestBody = buildRequestBody(fullBody, acquired.cached);
@@ -849,12 +840,7 @@ export const tryProxyCodexWebSocket = async (
       ...requestBody,
       type: "response.create",
     });
-    const maxRequestBytes = input.maxRequestBytes ?? resolveMaxRequestBytes();
-    if (textEncoder.encode(requestPayloadText).byteLength > maxRequestBytes) {
-      acquired.release(false);
-      markSessionFallback(cacheKey);
-      return null;
-    }
+    requestBytes = textEncoder.encode(requestPayloadText).byteLength;
   } catch (error) {
     acquired?.release(false);
     if (!input.signal?.aborted && !isSessionConcurrencyError(error)) {
@@ -893,6 +879,7 @@ export const tryProxyCodexWebSocket = async (
       terminal,
       queueLength: queue.length,
       connectionLimitAttempts,
+      requestBytes,
       ...fields,
     });
   };

--- a/src/providers/proxies/codex-websocket.ts
+++ b/src/providers/proxies/codex-websocket.ts
@@ -23,6 +23,7 @@ const RESPONSE_IDLE_TIMEOUT_MS = 5 * 60 * 1000;
 const MAX_SOCKET_AGE_MS = 55 * 60 * 1000;
 const CONNECTION_LIMIT_RETRIES = 5;
 const STREAM_FAILURE_RETRIES = 5;
+const MAX_FALLBACK_SESSIONS = 1000;
 const CONNECTION_LIMIT_REACHED_CODE = "websocket_connection_limit_reached";
 const WEBSOCKET_MESSAGE_TOO_BIG_CLOSE_CODE = 1009;
 const textEncoder = new TextEncoder();
@@ -85,7 +86,7 @@ type CachedSocket = {
 };
 
 const socketCache = new Map<string, CachedSocket>();
-const fallbackSocketKeys = new Map<string, ReturnType<typeof setTimeout>>();
+const fallbackSocketKeys = new Set<string>();
 const streamFailureCounts = new Map<string, number>();
 const pendingSocketKeys = new Set<string>();
 const suppressContinuationStoreKeys = new Set<string>();
@@ -221,11 +222,7 @@ const readWebSocketCloseCode = (error: unknown): number | null => {
 };
 
 const clearSessionFallback = (key: string): void => {
-  const timer = fallbackSocketKeys.get(key);
-  if (timer) {
-    clearTimeout(timer);
-    fallbackSocketKeys.delete(key);
-  }
+  fallbackSocketKeys.delete(key);
 };
 
 const markSessionFallback = (key: string | null): void => {
@@ -233,11 +230,14 @@ const markSessionFallback = (key: string | null): void => {
     return;
   }
   clearSessionFallback(key);
-  const timer = setTimeout(() => {
-    fallbackSocketKeys.delete(key);
-    streamFailureCounts.delete(key);
-  }, SESSION_SOCKET_TTL_MS);
-  fallbackSocketKeys.set(key, timer);
+  if (fallbackSocketKeys.size >= MAX_FALLBACK_SESSIONS) {
+    const oldestKey = fallbackSocketKeys.values().next().value;
+    if (typeof oldestKey === "string") {
+      fallbackSocketKeys.delete(oldestKey);
+      streamFailureCounts.delete(oldestKey);
+    }
+  }
+  fallbackSocketKeys.add(key);
 };
 
 const clearSessionStreamFailures = (key: string | null): void => {
@@ -272,7 +272,6 @@ const scheduleExpiry = (key: string, cached: CachedSocket): void => {
 
     closeSocket(cached.socket);
     socketCache.delete(key);
-    clearSessionFallback(key);
     clearSessionStreamFailures(key);
   }, SESSION_SOCKET_TTL_MS);
 };
@@ -470,9 +469,6 @@ export const closeCodexWebSocketSessions = (): void => {
     closeSocket(cached.socket);
   }
   socketCache.clear();
-  for (const timer of fallbackSocketKeys.values()) {
-    clearTimeout(timer);
-  }
   fallbackSocketKeys.clear();
   streamFailureCounts.clear();
 };

--- a/src/providers/proxies/codex-websocket.ts
+++ b/src/providers/proxies/codex-websocket.ts
@@ -897,6 +897,9 @@ export const tryProxyCodexWebSocket = async (
   let retryingConnectionLimit = false;
   let responseIdleTimer: ReturnType<typeof setTimeout> | null = null;
   let clearStreamKeepAlive: (() => void) | null = null;
+  let payloadCount = 0;
+  let lastUpstreamEventAt = startedAt;
+  let lastDownstreamWriteAt = startedAt;
   let messageChain = Promise.resolve();
   let wake: (() => void) | null = null;
   const queue: Record<string, unknown>[] = [];
@@ -912,6 +915,9 @@ export const tryProxyCodexWebSocket = async (
       queueLength: queue.length,
       connectionLimitAttempts,
       requestBytes,
+      payloadCount,
+      upstreamIdleMs: Date.now() - lastUpstreamEventAt,
+      downstreamIdleMs: Date.now() - lastDownstreamWriteAt,
       ...fields,
     });
   };
@@ -1038,12 +1044,7 @@ export const tryProxyCodexWebSocket = async (
     clearStreamKeepAlive?.();
     cleanup();
     active.release(false);
-    if (isUserCancelledStage(stage)) {
-      logStreamAnomaly("codex_websocket_stream_cancelled", {
-        stage,
-        ...errorLogFields(error),
-      });
-    } else {
+    if (!isUserCancelledStage(stage)) {
       const webSocketCloseCode = readWebSocketCloseCode(error);
       const immediateFallback =
         stage === "socket_closed_before_terminal" &&
@@ -1136,6 +1137,8 @@ export const tryProxyCodexWebSocket = async (
       return;
     }
     resetResponseIdleTimer("idle_timeout_waiting_for_websocket");
+    payloadCount++;
+    lastUpstreamEventAt = Date.now();
 
     if (!emittedPayload && isConnectionLimitPayload(payload)) {
       retryConnectionLimit().catch((error: unknown) => {
@@ -1209,6 +1212,7 @@ export const tryProxyCodexWebSocket = async (
     }
 
     controller.enqueue(encodeSse(payload));
+    lastDownstreamWriteAt = Date.now();
     if (isTerminalPayload(payload)) {
       terminal = true;
       finalEventType = payload.type;
@@ -1231,6 +1235,7 @@ export const tryProxyCodexWebSocket = async (
         }
       }
       controller.enqueue(encodeDoneSse());
+      lastDownstreamWriteAt = Date.now();
       finish();
     }
   };
@@ -1241,6 +1246,9 @@ export const tryProxyCodexWebSocket = async (
         provider: "codex",
         transport: "websocket_sse",
         getElapsedMs: () => Date.now() - startedAt,
+        onKeepAlive: () => {
+          lastDownstreamWriteAt = Date.now();
+        },
       }).clear;
     },
     async pull(controller): Promise<void> {

--- a/src/providers/proxies/codex-websocket.ts
+++ b/src/providers/proxies/codex-websocket.ts
@@ -1,3 +1,5 @@
+import { HttpsProxyAgent } from "https-proxy-agent";
+import { getProxyForUrl } from "proxy-from-env";
 import WebSocket from "ws";
 
 import {
@@ -31,7 +33,8 @@ type WebSocketListener = (event: unknown) => void;
 type WebSocketLike = {
   readonly readyState?: number;
   close(code?: number, reason?: string): void;
-  send(data: string): void;
+  terminate?: () => void;
+  send(data: string, callback?: (error?: Error) => void): void;
   addEventListener(type: WebSocketEventType, listener: WebSocketListener): void;
   removeEventListener(
     type: WebSocketEventType,
@@ -41,7 +44,7 @@ type WebSocketLike = {
 
 type WebSocketConstructor = new (
   url: string,
-  protocols?: string | string[] | { headers?: Record<string, string> }
+  options?: { headers?: Record<string, string>; agent?: unknown }
 ) => WebSocketLike;
 
 let webSocketConstructorOverride: WebSocketConstructor | null = null;
@@ -151,6 +154,18 @@ const closeSocket = (socket: WebSocketLike): void => {
     socket.close(1000, "done");
   } catch {
     // Ignore close failures from already-closed sockets.
+  }
+};
+
+const terminateSocket = (socket: WebSocketLike): void => {
+  try {
+    if (socket.terminate) {
+      socket.terminate();
+      return;
+    }
+    socket.close(1001, "invalid");
+  } catch {
+    // Ignore termination failures from already-closed sockets.
   }
 };
 
@@ -317,19 +332,24 @@ const connectWebSocket = (
     const onClose = (event: unknown): void =>
       fail(extractWebSocketCloseError(event));
     const onAbort = (): void => {
-      closeSocket(socket);
       fail(new Error("Request was aborted"));
+      terminateSocket(socket);
     };
     const onTimeout = (): void => {
-      closeSocket(socket);
       fail(
         new Error(`WebSocket connect timeout after ${CONNECT_TIMEOUT_MS}ms`)
       );
+      terminateSocket(socket);
     };
 
     try {
-      socket = new WebSocketCtor(resolveCodexWebSocketUrl(), {
+      const webSocketUrl = resolveCodexWebSocketUrl();
+      const proxyUrl = getProxyForUrl(
+        webSocketUrl.replace(/^wss:/u, "https:").replace(/^ws:/u, "http:")
+      );
+      socket = new WebSocketCtor(webSocketUrl, {
         headers: headersToRecord(headers),
+        ...(proxyUrl ? { agent: new HttpsProxyAgent(proxyUrl) } : {}),
       });
     } catch (error) {
       reject(error instanceof Error ? error : new Error(String(error)));
@@ -358,7 +378,13 @@ const acquireSocket = async (
     const acquired = {
       socket,
       cached: null,
-      release: (): void => closeSocket(acquired.socket),
+      release(keep: boolean): void {
+        if (keep) {
+          closeSocket(acquired.socket);
+          return;
+        }
+        terminateSocket(acquired.socket);
+      },
     };
     return acquired;
   }
@@ -383,7 +409,7 @@ const acquireSocket = async (
         cached: existing,
         release(keep: boolean): void {
           if (!(keep && isSocketOpen(existing.socket))) {
-            closeSocket(existing.socket);
+            terminateSocket(existing.socket);
             socketCache.delete(cacheKey);
             return;
           }
@@ -426,7 +452,7 @@ const acquireSocket = async (
     cached,
     release(keep: boolean): void {
       if (!(keep && isSocketOpen(cached.socket))) {
-        closeSocket(cached.socket);
+        terminateSocket(cached.socket);
         socketCache.delete(cacheKey);
         return;
       }
@@ -954,8 +980,17 @@ export const tryProxyCodexWebSocket = async (
       return;
     }
     try {
-      active.socket.send(requestPayloadText);
-      resetResponseIdleTimer("idle_timeout_waiting_for_websocket");
+      resetResponseIdleTimer("idle_timeout_sending_websocket_request");
+      active.socket.send(requestPayloadText, (error?: Error) => {
+        if (settled) {
+          return;
+        }
+        if (error) {
+          fail("send_failed", error);
+          return;
+        }
+        resetResponseIdleTimer("idle_timeout_waiting_for_websocket");
+      });
     } catch (error) {
       fail("send_failed", error);
     }
@@ -979,7 +1014,7 @@ export const tryProxyCodexWebSocket = async (
     active.socket.removeEventListener("message", onMessage);
     active.socket.removeEventListener("error", onError);
     active.socket.removeEventListener("close", onClose);
-    closeSocket(active.socket);
+    terminateSocket(active.socket);
 
     try {
       const nextSocket = await connectWebSocket(headers, input.signal);

--- a/src/providers/proxies/codex-websocket.ts
+++ b/src/providers/proxies/codex-websocket.ts
@@ -11,6 +11,7 @@ import { readOpenAiResponsesUsageFromSseEvent } from "../../usage/token-usage";
 import type { TokenUsage } from "../../usage/token-usage";
 import { errorLogFields, logWarn } from "../../utils/log";
 import { isObjectRecord, readBooleanField } from "../../utils/object";
+import { createSseKeepAlive, createSseResponseHeaders } from "./sse-keepalive";
 
 const SESSION_SOCKET_TTL_MS = 5 * 60 * 1000;
 const CONNECT_TIMEOUT_MS = 15_000;
@@ -91,9 +92,7 @@ const headersToRecord = (headers: Headers): Record<string, string> => {
 
 const createSseResponse = (body: ReadableStream<Uint8Array>): Response =>
   new Response(body, {
-    headers: {
-      "content-type": "text/event-stream",
-    },
+    headers: createSseResponseHeaders(),
   });
 
 const readString = (value: unknown): string | null => {
@@ -828,6 +827,7 @@ export const tryProxyCodexWebSocket = async (
   let connectionLimitAttempts = 0;
   let retryingConnectionLimit = false;
   let responseIdleTimer: ReturnType<typeof setTimeout> | null = null;
+  let clearStreamKeepAlive: (() => void) | null = null;
   let messageChain = Promise.resolve();
   let wake: (() => void) | null = null;
   const queue: Record<string, unknown>[] = [];
@@ -958,6 +958,7 @@ export const tryProxyCodexWebSocket = async (
     settled = true;
     keepSocket = false;
     failure = error;
+    clearStreamKeepAlive?.();
     cleanup();
     active.release(false);
     if (isUserCancelledStage(stage)) {
@@ -991,6 +992,7 @@ export const tryProxyCodexWebSocket = async (
       return;
     }
     settled = true;
+    clearStreamKeepAlive?.();
     cleanup();
     const canStoreContinuation = Boolean(
       active.cached &&
@@ -1157,6 +1159,13 @@ export const tryProxyCodexWebSocket = async (
   };
 
   const stream = new ReadableStream<Uint8Array>({
+    start(controller): void {
+      clearStreamKeepAlive = createSseKeepAlive(controller, {
+        provider: "codex",
+        transport: "websocket_sse",
+        getElapsedMs: () => Date.now() - startedAt,
+      }).clear;
+    },
     async pull(controller): Promise<void> {
       while (!queue.length && !settled) {
         await new Promise<void>((resolve) => {
@@ -1185,6 +1194,7 @@ export const tryProxyCodexWebSocket = async (
       controller.close();
     },
     cancel(): void {
+      clearStreamKeepAlive?.();
       if (settled) {
         return;
       }

--- a/src/providers/proxies/codex-websocket.ts
+++ b/src/providers/proxies/codex-websocket.ts
@@ -21,6 +21,8 @@ const CONNECTION_LIMIT_RETRIES = 5;
 const STREAM_FAILURE_RETRIES = 5;
 const CONNECTION_LIMIT_REACHED_CODE = "websocket_connection_limit_reached";
 const WEBSOCKET_MESSAGE_TOO_BIG_CLOSE_CODE = 1009;
+const DEFAULT_MAX_WEBSOCKET_REQUEST_BYTES = 8 * 1024 * 1024;
+const textEncoder = new TextEncoder();
 
 type WebSocketEventType = "open" | "message" | "error" | "close";
 type WebSocketListener = (event: unknown) => void;
@@ -53,6 +55,7 @@ type CodexWebSocketInput = {
   upstreamSessionId?: string | null;
   onTokenUsage?: ((usage: TokenUsage) => void) | null;
   signal?: AbortSignal;
+  maxRequestBytes?: number;
 };
 
 type ContinuationState = {
@@ -102,6 +105,39 @@ const readString = (value: unknown): string | null => {
 
   const trimmed = value.trim();
   return trimmed || null;
+};
+
+const resolveMaxRequestBytes = (): number => {
+  const configured = Number(process.env.CODEX_WEBSOCKET_MAX_REQUEST_BYTES);
+  if (Number.isFinite(configured) && configured >= 0) {
+    return configured === 0 ? Number.POSITIVE_INFINITY : configured;
+  }
+  return DEFAULT_MAX_WEBSOCKET_REQUEST_BYTES;
+};
+
+const isCompactionRequest = (
+  body: Record<string, unknown>,
+  headers: Headers
+): boolean => {
+  const clientMetadata = isObjectRecord(body.client_metadata)
+    ? body.client_metadata
+    : null;
+  const rawMetadata =
+    readString(clientMetadata?.["x-codex-turn-metadata"]) ??
+    readString(headers.get("x-codex-turn-metadata"));
+  if (!rawMetadata) {
+    return false;
+  }
+
+  try {
+    const metadata = JSON.parse(rawMetadata) as unknown;
+    return (
+      isObjectRecord(metadata) &&
+      readString(metadata.request_kind)?.toLowerCase() === "compaction"
+    );
+  } catch {
+    return false;
+  }
 };
 
 const isSocketOpen = (socket: WebSocketLike): boolean =>
@@ -631,10 +667,9 @@ const buildRequestBody = (
 };
 
 const encodeSse = (payload: unknown): Uint8Array =>
-  new TextEncoder().encode(`data: ${JSON.stringify(payload)}\n\n`);
+  textEncoder.encode(`data: ${JSON.stringify(payload)}\n\n`);
 
-const encodeDoneSse = (): Uint8Array =>
-  new TextEncoder().encode("data: [DONE]\n\n");
+const encodeDoneSse = (): Uint8Array => textEncoder.encode("data: [DONE]\n\n");
 
 const decodeMessageData = async (data: unknown): Promise<string | null> => {
   if (typeof data === "string") {
@@ -792,6 +827,11 @@ export const tryProxyCodexWebSocket = async (
   const cacheKey = sessionId ? `${input.accountKey}:${sessionId}` : null;
   const headers = buildWebSocketHeaders(input.headers, requestId);
 
+  if (isCompactionRequest(body, input.headers)) {
+    markSessionFallback(cacheKey);
+    return null;
+  }
+
   if (cacheKey && fallbackSocketKeys.has(cacheKey)) {
     return null;
   }
@@ -801,9 +841,20 @@ export const tryProxyCodexWebSocket = async (
     sessionId ? { ...body, prompt_cache_key: requestId } : body
   );
   let requestBody: Record<string, unknown>;
+  let requestPayloadText: string;
   try {
     acquired = await acquireSocket(headers, cacheKey, input.signal);
     requestBody = buildRequestBody(fullBody, acquired.cached);
+    requestPayloadText = JSON.stringify({
+      ...requestBody,
+      type: "response.create",
+    });
+    const maxRequestBytes = input.maxRequestBytes ?? resolveMaxRequestBytes();
+    if (textEncoder.encode(requestPayloadText).byteLength > maxRequestBytes) {
+      acquired.release(false);
+      markSessionFallback(cacheKey);
+      return null;
+    }
   } catch (error) {
     acquired?.release(false);
     if (!input.signal?.aborted && !isSessionConcurrencyError(error)) {
@@ -906,9 +957,7 @@ export const tryProxyCodexWebSocket = async (
       return;
     }
     try {
-      active.socket.send(
-        JSON.stringify({ ...requestBody, type: "response.create" })
-      );
+      active.socket.send(requestPayloadText);
       resetResponseIdleTimer("idle_timeout_waiting_for_websocket");
     } catch (error) {
       fail("send_failed", error);

--- a/src/providers/proxies/codex-websocket.ts
+++ b/src/providers/proxies/codex-websocket.ts
@@ -23,7 +23,7 @@ const RESPONSE_IDLE_TIMEOUT_MS = 5 * 60 * 1000;
 const MAX_SOCKET_AGE_MS = 55 * 60 * 1000;
 const CONNECTION_LIMIT_RETRIES = 5;
 const STREAM_FAILURE_RETRIES = 5;
-const MAX_FALLBACK_SESSIONS = 1000;
+const MAX_TRACKED_FAILURE_SESSIONS = 1000;
 const CONNECTION_LIMIT_REACHED_CODE = "websocket_connection_limit_reached";
 const WEBSOCKET_MESSAGE_TOO_BIG_CLOSE_CODE = 1009;
 const textEncoder = new TextEncoder();
@@ -86,7 +86,7 @@ type CachedSocket = {
 };
 
 const socketCache = new Map<string, CachedSocket>();
-const fallbackSocketKeys = new Set<string>();
+const fallbackSocketKeys = new Map<string, ReturnType<typeof setTimeout>>();
 const streamFailureCounts = new Map<string, number>();
 const pendingSocketKeys = new Set<string>();
 const suppressContinuationStoreKeys = new Set<string>();
@@ -222,6 +222,10 @@ const readWebSocketCloseCode = (error: unknown): number | null => {
 };
 
 const clearSessionFallback = (key: string): void => {
+  const timer = fallbackSocketKeys.get(key);
+  if (timer) {
+    clearTimeout(timer);
+  }
   fallbackSocketKeys.delete(key);
 };
 
@@ -230,14 +234,11 @@ const markSessionFallback = (key: string | null): void => {
     return;
   }
   clearSessionFallback(key);
-  if (fallbackSocketKeys.size >= MAX_FALLBACK_SESSIONS) {
-    const oldestKey = fallbackSocketKeys.values().next().value;
-    if (typeof oldestKey === "string") {
-      fallbackSocketKeys.delete(oldestKey);
-      streamFailureCounts.delete(oldestKey);
-    }
-  }
-  fallbackSocketKeys.add(key);
+  const timer = setTimeout(() => {
+    fallbackSocketKeys.delete(key);
+    streamFailureCounts.delete(key);
+  }, SESSION_SOCKET_TTL_MS);
+  fallbackSocketKeys.set(key, timer);
 };
 
 const clearSessionStreamFailures = (key: string | null): void => {
@@ -252,6 +253,15 @@ const recordSessionStreamFailure = (key: string | null): number => {
     return 0;
   }
 
+  if (
+    !streamFailureCounts.has(key) &&
+    streamFailureCounts.size >= MAX_TRACKED_FAILURE_SESSIONS
+  ) {
+    const oldestKey = streamFailureCounts.keys().next().value;
+    if (typeof oldestKey === "string") {
+      streamFailureCounts.delete(oldestKey);
+    }
+  }
   const failures = (streamFailureCounts.get(key) ?? 0) + 1;
   streamFailureCounts.set(key, failures);
   if (failures > STREAM_FAILURE_RETRIES) {
@@ -469,6 +479,9 @@ export const closeCodexWebSocketSessions = (): void => {
     closeSocket(cached.socket);
   }
   socketCache.clear();
+  for (const timer of fallbackSocketKeys.values()) {
+    clearTimeout(timer);
+  }
   fallbackSocketKeys.clear();
   streamFailureCounts.clear();
 };

--- a/src/providers/proxies/openai-sse-passthrough.ts
+++ b/src/providers/proxies/openai-sse-passthrough.ts
@@ -135,75 +135,61 @@ export const createOpenAiSseUsagePassthrough = (
 
   const stream = new ReadableStream<Uint8Array>({
     start(controller): void {
-      const keepAlive = createSseKeepAlive(controller, {
+      clearKeepAlive = createSseKeepAlive(controller, {
         provider: "openai",
         transport: "sse",
         getElapsedMs: () => Date.now() - startedAt,
-      });
-      clearKeepAlive = keepAlive.clear;
+      }).clear;
+    },
+    async pull(controller): Promise<void> {
+      try {
+        let result = await reader.read();
+        while (!(result.done || result.value)) {
+          result = await reader.read();
+        }
 
-      const pump = async (): Promise<void> => {
-        try {
-          while (true) {
-            const { done, value } = await reader.read();
-            if (done) {
-              if (closed) {
-                clearKeepAlive?.();
-                return;
-              }
-              pendingText += decoder.decode();
-              pendingText = readLatestUsageFromSse(
-                `${pendingText}\n\n`,
-                usageState,
-                input.extractUsage
-              );
-              if (usageState.latestUsage) {
-                input.onTokenUsage?.(usageState.latestUsage);
-              }
-              if (usageState.terminalAnomaly) {
-                logStreamAnomaly("openai_sse_terminal_anomaly", {
-                  terminalAnomaly: usageState.terminalAnomaly,
-                });
-              }
-              closed = true;
-              clearKeepAlive?.();
-              controller.close();
-              return;
-            }
-
-            if (!value) {
-              continue;
-            }
-
-            bytes += value.byteLength;
-            chunks++;
-            lastChunkAt = Date.now();
-            pendingText += decoder.decode(value, { stream: true });
-            pendingText = readLatestUsageFromSse(
-              pendingText,
-              usageState,
-              input.extractUsage
-            );
-            try {
-              controller.enqueue(value);
-            } catch (error) {
-              logStreamAnomaly("openai_sse_enqueue_failed", {}, error);
-              throw error;
-            }
-          }
-        } catch (error) {
+        if (result.done) {
           if (closed) {
             clearKeepAlive?.();
             return;
           }
+          pendingText += decoder.decode();
+          pendingText = readLatestUsageFromSse(
+            `${pendingText}\n\n`,
+            usageState,
+            input.extractUsage
+          );
+          if (usageState.latestUsage) {
+            input.onTokenUsage?.(usageState.latestUsage);
+          }
+          if (usageState.terminalAnomaly) {
+            logStreamAnomaly("openai_sse_terminal_anomaly", {
+              terminalAnomaly: usageState.terminalAnomaly,
+            });
+          }
           closed = true;
           clearKeepAlive?.();
-          logStreamAnomaly("openai_sse_stream_failed", {}, error);
-          controller.error(error);
+          controller.close();
+          return;
         }
-      };
 
-      pump().catch((error: unknown) => {
+        const value = result.value;
+        bytes += value.byteLength;
+        chunks++;
+        lastChunkAt = Date.now();
+        pendingText += decoder.decode(value, { stream: true });
+        pendingText = readLatestUsageFromSse(
+          pendingText,
+          usageState,
+          input.extractUsage
+        );
+        try {
+          controller.enqueue(value);
+        } catch (error) {
+          logStreamAnomaly("openai_sse_enqueue_failed", {}, error);
+          throw error;
+        }
+      } catch (error) {
         if (closed) {
           clearKeepAlive?.();
           return;
@@ -212,7 +198,7 @@ export const createOpenAiSseUsagePassthrough = (
         clearKeepAlive?.();
         logStreamAnomaly("openai_sse_stream_failed", {}, error);
         controller.error(error);
-      });
+      }
     },
     cancel(reason): Promise<void> {
       if (!closed) {

--- a/src/providers/proxies/openai-sse-passthrough.ts
+++ b/src/providers/proxies/openai-sse-passthrough.ts
@@ -113,6 +113,7 @@ export const createOpenAiSseUsagePassthrough = (
   let bytes = 0;
   let chunks = 0;
   let lastChunkAt = startedAt;
+  let lastWriteAt = startedAt;
   let closed = false;
   let clearKeepAlive: (() => void) | null = null;
 
@@ -126,6 +127,7 @@ export const createOpenAiSseUsagePassthrough = (
       transport: "sse",
       elapsedMs: Date.now() - startedAt,
       idleMs: Date.now() - lastChunkAt,
+      downstreamIdleMs: Date.now() - lastWriteAt,
       bytes,
       chunks,
       ...fields,
@@ -139,6 +141,9 @@ export const createOpenAiSseUsagePassthrough = (
         provider: "openai",
         transport: "sse",
         getElapsedMs: () => Date.now() - startedAt,
+        onKeepAlive: () => {
+          lastWriteAt = Date.now();
+        },
       }).clear;
     },
     async pull(controller): Promise<void> {
@@ -185,6 +190,7 @@ export const createOpenAiSseUsagePassthrough = (
         );
         try {
           controller.enqueue(value);
+          lastWriteAt = Date.now();
         } catch (error) {
           logStreamAnomaly("openai_sse_enqueue_failed", {}, error);
           throw error;
@@ -201,9 +207,6 @@ export const createOpenAiSseUsagePassthrough = (
       }
     },
     cancel(reason): Promise<void> {
-      if (!closed) {
-        logStreamAnomaly("openai_sse_downstream_cancelled", {}, reason);
-      }
       closed = true;
       clearKeepAlive?.();
       return reader.cancel(reason);

--- a/src/providers/proxies/openai-sse-passthrough.ts
+++ b/src/providers/proxies/openai-sse-passthrough.ts
@@ -9,6 +9,7 @@ type OpenAiSsePassthroughInput = {
   response: Response;
   extractUsage: SseUsageExtractor;
   onTokenUsage?: ((usage: TokenUsage) => void) | null | undefined;
+  keepAliveIntervalMs?: number;
 };
 
 const readSseTerminalAnomaly = (payload: unknown): string | null => {
@@ -104,6 +105,12 @@ export const createOpenAiSseUsagePassthrough = (
   const reader = input.response.body.getReader();
   const decoder = new TextDecoder();
   const startedAt = Date.now();
+  const contentType = (
+    input.response.headers.get("content-type") ?? ""
+  ).toLowerCase();
+  // Codex omits the content-type header on SSE streams; anything explicitly
+  // non-SSE (e.g. JSON error bodies) must not receive keepalive comments.
+  const isSseBody = !contentType || contentType.includes("text/event-stream");
   const usageState = {
     eventDataLines: [] as string[],
     latestUsage: null as TokenUsage | null,
@@ -137,6 +144,9 @@ export const createOpenAiSseUsagePassthrough = (
 
   const stream = new ReadableStream<Uint8Array>({
     start(controller): void {
+      if (!isSseBody) {
+        return;
+      }
       clearKeepAlive = createSseKeepAlive(controller, {
         provider: "openai",
         transport: "sse",
@@ -144,6 +154,9 @@ export const createOpenAiSseUsagePassthrough = (
         onKeepAlive: () => {
           lastWriteAt = Date.now();
         },
+        ...(input.keepAliveIntervalMs
+          ? { intervalMs: input.keepAliveIntervalMs }
+          : {}),
       }).clear;
     },
     async pull(controller): Promise<void> {

--- a/src/providers/proxies/openai-sse-passthrough.ts
+++ b/src/providers/proxies/openai-sse-passthrough.ts
@@ -1,7 +1,7 @@
 import type { TokenUsage } from "../../usage/token-usage";
 import { errorLogFields, logWarn } from "../../utils/log";
 import { isObjectRecord } from "../../utils/object";
-import { createSseKeepAlive } from "./sse-keepalive";
+import { createSseKeepAlive, createSseResponseHeaders } from "./sse-keepalive";
 
 type SseUsageExtractor = (payload: unknown) => TokenUsage | null;
 
@@ -227,6 +227,6 @@ export const createOpenAiSseUsagePassthrough = (
   return new Response(stream, {
     status: input.response.status,
     statusText: input.response.statusText,
-    headers: input.response.headers,
+    headers: createSseResponseHeaders(input.response.headers),
   });
 };

--- a/src/providers/proxies/sse-keepalive.ts
+++ b/src/providers/proxies/sse-keepalive.ts
@@ -20,6 +20,7 @@ type SseKeepAliveInput = {
   transport: string;
   getElapsedMs: () => number;
   onKeepAlive?: () => void;
+  intervalMs?: number;
 };
 
 export const createSseKeepAlive = (
@@ -45,7 +46,7 @@ export const createSseKeepAlive = (
         ...errorLogFields(error),
       });
     }
-  }, SSE_KEEPALIVE_INTERVAL_MS);
+  }, input.intervalMs ?? SSE_KEEPALIVE_INTERVAL_MS);
 
   return {
     clear(): void {

--- a/src/providers/proxies/sse-keepalive.ts
+++ b/src/providers/proxies/sse-keepalive.ts
@@ -8,7 +8,9 @@ export const createSseResponseHeaders = (source?: HeadersInit): Headers => {
   headers.delete("content-encoding");
   headers.delete("content-length");
   headers.set("cache-control", "no-cache, no-transform");
-  headers.set("content-type", "text/event-stream");
+  if (!headers.has("content-type")) {
+    headers.set("content-type", "text/event-stream");
+  }
   headers.set("x-accel-buffering", "no");
   return headers;
 };

--- a/src/providers/proxies/sse-keepalive.ts
+++ b/src/providers/proxies/sse-keepalive.ts
@@ -3,6 +3,16 @@ import { errorLogFields, logWarn } from "../../utils/log";
 const SSE_KEEPALIVE_INTERVAL_MS = 25_000;
 const SSE_KEEPALIVE_BYTES = new TextEncoder().encode(": kleis-keepalive\n\n");
 
+export const createSseResponseHeaders = (source?: HeadersInit): Headers => {
+  const headers = new Headers(source);
+  headers.delete("content-encoding");
+  headers.delete("content-length");
+  headers.set("cache-control", "no-cache, no-transform");
+  headers.set("content-type", "text/event-stream");
+  headers.set("x-accel-buffering", "no");
+  return headers;
+};
+
 type SseKeepAliveInput = {
   provider: string;
   transport: string;

--- a/src/providers/proxies/sse-keepalive.ts
+++ b/src/providers/proxies/sse-keepalive.ts
@@ -17,6 +17,7 @@ type SseKeepAliveInput = {
   provider: string;
   transport: string;
   getElapsedMs: () => number;
+  onKeepAlive?: () => void;
 };
 
 export const createSseKeepAlive = (
@@ -31,6 +32,7 @@ export const createSseKeepAlive = (
 
     try {
       controller.enqueue(SSE_KEEPALIVE_BYTES);
+      input.onKeepAlive?.();
     } catch (error) {
       active = false;
       clearInterval(timer);

--- a/tests/providers/proxy-contract.test.ts
+++ b/tests/providers/proxy-contract.test.ts
@@ -654,6 +654,43 @@ describe("proxy contract: codex", () => {
     });
   });
 
+  test("does not inject keepalives into non-SSE bodies", async () => {
+    const encoder = new TextEncoder();
+    const createSlowResponse = (
+      payload: string,
+      contentType: string | null
+    ): Response =>
+      new Response(
+        new ReadableStream<Uint8Array>({
+          async start(controller): Promise<void> {
+            controller.enqueue(encoder.encode(payload.slice(0, 4)));
+            await new Promise((resolve) => setTimeout(resolve, 30));
+            controller.enqueue(encoder.encode(payload.slice(4)));
+            controller.close();
+          },
+        }),
+        contentType ? { headers: { "content-type": contentType } } : {}
+      );
+
+    const jsonBody = JSON.stringify({ error: { message: "slow error" } });
+    const jsonResponse = createOpenAiSseUsagePassthrough({
+      response: createSlowResponse(jsonBody, "application/json"),
+      extractUsage: () => null,
+      keepAliveIntervalMs: 5,
+    });
+    expect(await jsonResponse.text()).toBe(jsonBody);
+
+    const sseBody = 'data: {"type":"response.completed"}\n\n';
+    const sseResponse = createOpenAiSseUsagePassthrough({
+      response: createSlowResponse(sseBody, null),
+      extractUsage: () => null,
+      keepAliveIntervalMs: 5,
+    });
+    const sseText = await sseResponse.text();
+    expect(sseText).toContain("response.completed");
+    expect(sseText).toContain(": kleis-keepalive");
+  });
+
   test("routes compaction turns over HTTP instead of WebSocket", async () => {
     const sentBodies: unknown[] = [];
     const sockets = installManualCodexWebSocketMock(sentBodies);

--- a/tests/providers/proxy-contract.test.ts
+++ b/tests/providers/proxy-contract.test.ts
@@ -616,6 +616,60 @@ describe("proxy contract: codex", () => {
     await transformed.body?.cancel();
   });
 
+  test("routes compaction turns over HTTP instead of WebSocket", async () => {
+    const sentBodies: unknown[] = [];
+    const sockets = installManualCodexWebSocketMock(sentBodies);
+    const headers = new Headers({
+      authorization: "Bearer codex-access",
+      [CODEX_ACCOUNT_ID_HEADER]: "acct_1",
+      "x-session-affinity": "compaction-session",
+    });
+
+    const response = await tryProxyCodexWebSocket({
+      headers,
+      bodyJson: {
+        model: "gpt-5.5",
+        stream: true,
+        client_metadata: {
+          "x-codex-turn-metadata": JSON.stringify({
+            request_kind: "compaction",
+          }),
+        },
+        input: [{ role: "user", content: "compact" }],
+      },
+      accountKey: "key-1:account-1",
+    });
+
+    expect(response).toBeNull();
+    expect(sockets).toHaveLength(0);
+    expect(sentBodies).toHaveLength(0);
+  });
+
+  test("routes oversized response.create frames over HTTP", async () => {
+    const sentBodies: unknown[] = [];
+    const sockets = installManualCodexWebSocketMock(sentBodies);
+    const headers = new Headers({
+      authorization: "Bearer codex-access",
+      [CODEX_ACCOUNT_ID_HEADER]: "acct_1",
+      "x-session-affinity": "oversized-session",
+    });
+
+    const response = await tryProxyCodexWebSocket({
+      headers,
+      bodyJson: {
+        model: "gpt-5.5",
+        stream: true,
+        input: [{ role: "user", content: "x".repeat(256) }],
+      },
+      accountKey: "key-1:account-1",
+      maxRequestBytes: 128,
+    });
+
+    expect(response).toBeNull();
+    expect(sockets).toHaveLength(1);
+    expect(sentBodies).toHaveLength(0);
+  });
+
   test("uses websocket cached delta transport for streaming requests", async () => {
     const firstAssistantItem = {
       type: "message",

--- a/tests/providers/proxy-contract.test.ts
+++ b/tests/providers/proxy-contract.test.ts
@@ -82,14 +82,12 @@ type MockCodexWebSocketResponse = {
 
 type MockWebSocketOptions = {
   headers?: Record<string, string>;
-  agent?: unknown;
 };
 
 const installCodexWebSocketMock = (
   responses: MockCodexWebSocketResponse[],
   sentBodies: unknown[],
-  constructorHeaders: Record<string, string>[] = [],
-  constructorOptions: MockWebSocketOptions[] = []
+  constructorHeaders: Record<string, string>[] = []
 ): void => {
   class MockWebSocket {
     static OPEN = 1;
@@ -100,9 +98,6 @@ const installCodexWebSocketMock = (
     >();
 
     constructor(_url: string, options?: MockWebSocketOptions) {
-      if (options) {
-        constructorOptions.push(options);
-      }
       if (options?.headers) {
         constructorHeaders.push(options.headers);
       }
@@ -718,59 +713,6 @@ describe("proxy contract: codex", () => {
     expect(response).toBeNull();
     expect(sockets).toHaveLength(0);
     expect(sentBodies).toHaveLength(0);
-  });
-
-  test("uses standard proxy environment for websocket connections", async () => {
-    const sentBodies: unknown[] = [];
-    const constructorOptions: MockWebSocketOptions[] = [];
-    installCodexWebSocketMock(
-      [{ id: "resp_proxy" }],
-      sentBodies,
-      [],
-      constructorOptions
-    );
-    const originalHttpsProxy = process.env.HTTPS_PROXY;
-    const originalHttpsProxyLower = process.env.https_proxy;
-    const originalNoProxy = process.env.NO_PROXY;
-    const originalNoProxyLower = process.env.no_proxy;
-    const restoreEnvironment = (
-      key: string,
-      value: string | undefined
-    ): void => {
-      if (value === undefined) {
-        Reflect.deleteProperty(process.env, key);
-        return;
-      }
-      process.env[key] = value;
-    };
-    process.env.HTTPS_PROXY = "http://127.0.0.1:3128";
-    process.env.https_proxy = "http://127.0.0.1:3128";
-    process.env.NO_PROXY = "";
-    process.env.no_proxy = "";
-
-    try {
-      const response = await tryProxyCodexWebSocket({
-        headers: new Headers({
-          authorization: "Bearer codex-access",
-          [CODEX_ACCOUNT_ID_HEADER]: "acct_1",
-          "x-session-affinity": "proxy-session",
-        }),
-        bodyJson: {
-          model: "gpt-5.5",
-          stream: true,
-          input: [{ role: "user", content: "hello" }],
-        },
-        accountKey: "key-1:account-1",
-      });
-      await response?.text();
-    } finally {
-      restoreEnvironment("HTTPS_PROXY", originalHttpsProxy);
-      restoreEnvironment("https_proxy", originalHttpsProxyLower);
-      restoreEnvironment("NO_PROXY", originalNoProxy);
-      restoreEnvironment("no_proxy", originalNoProxyLower);
-    }
-
-    expect(constructorOptions[0]?.agent).toBeDefined();
   });
 
   test("terminates websocket when the downstream request aborts", async () => {

--- a/tests/providers/proxy-contract.test.ts
+++ b/tests/providers/proxy-contract.test.ts
@@ -1551,6 +1551,68 @@ describe("proxy contract: codex", () => {
     expect(sentBodies).toHaveLength(2);
   });
 
+  test("survives a socket close racing a connection limit retry", async () => {
+    const sentBodies: unknown[] = [];
+    const sockets = installManualCodexWebSocketMock(sentBodies);
+    const headers = new Headers({
+      authorization: "Bearer codex-access",
+      [CODEX_ACCOUNT_ID_HEADER]: "acct_1",
+      "x-session-affinity": "retry-close-race",
+    });
+    const bodyJson = {
+      model: "gpt-5-codex",
+      stream: true,
+      input: [
+        { role: "user", content: [{ type: "input_text", text: "Race" }] },
+      ],
+    };
+
+    const responsePromise = tryProxyCodexWebSocket({
+      headers,
+      bodyJson,
+      accountKey: "key-1:account-1",
+    });
+    await waitFor(() => sentBodies.length === 1);
+
+    // The upstream sends the connection limit error and immediately closes
+    // the socket; both events are already queued before the retry can
+    // detach its listeners.
+    sockets[0]?.dispatch("message", {
+      data: JSON.stringify({
+        type: "error",
+        error: { code: "websocket_connection_limit_reached" },
+      }),
+    });
+    sockets[0]?.dispatch("close", { code: 1006, reason: "Connection ended" });
+
+    await waitFor(() => sentBodies.length === 2 && sockets.length === 2);
+    sockets[1]?.dispatch("message", {
+      data: JSON.stringify({
+        type: "response.completed",
+        response: { id: "resp_race", status: "completed" },
+      }),
+    });
+
+    const response = await responsePromise;
+    expect(response).not.toBeNull();
+    expect(await response?.text()).toContain("response.completed");
+
+    // The stale close must not have marked the session for HTTP fallback.
+    const followUpPromise = tryProxyCodexWebSocket({
+      headers,
+      bodyJson,
+      accountKey: "key-1:account-1",
+    });
+    await waitFor(() => sentBodies.length === 3);
+    sockets.at(-1)?.dispatch("message", {
+      data: JSON.stringify({
+        type: "response.completed",
+        response: { id: "resp_follow", status: "completed" },
+      }),
+    });
+    expect(await followUpPromise).not.toBeNull();
+  });
+
   test("preserves websocket rate limit status_code errors", async () => {
     const sentBodies: unknown[] = [];
     const sockets = installManualCodexWebSocketMock(sentBodies);

--- a/tests/providers/proxy-contract.test.ts
+++ b/tests/providers/proxy-contract.test.ts
@@ -641,6 +641,9 @@ describe("proxy contract: codex", () => {
       onTokenUsage: capture.onTokenUsage,
     });
     expect(first).not.toBeNull();
+    expect(first?.headers.get("cache-control")).toBe("no-cache, no-transform");
+    expect(first?.headers.get("x-accel-buffering")).toBe("no");
+    expect(first?.headers.get("content-length")).toBeNull();
     await first?.text();
 
     const second = await tryProxyCodexWebSocket({
@@ -2283,6 +2286,11 @@ describe("proxy contract: claude", () => {
     );
     const transformedResponse = await result.transformResponse(sourceResponse);
 
+    expect(transformedResponse.headers.get("cache-control")).toBe(
+      "no-cache, no-transform"
+    );
+    expect(transformedResponse.headers.get("x-accel-buffering")).toBe("no");
+    expect(transformedResponse.headers.get("content-length")).toBeNull();
     const transformedText = await transformedResponse.text();
     expect(transformedText).toContain('"name":"shell"');
   });

--- a/tests/providers/proxy-contract.test.ts
+++ b/tests/providers/proxy-contract.test.ts
@@ -19,17 +19,16 @@ import { prepareClaudeProxyRequest } from "../../src/providers/proxies/claude-pr
 import { prepareCodexProxyRequest } from "../../src/providers/proxies/codex-proxy";
 import {
   closeCodexWebSocketSessions,
+  setCodexWebSocketConstructorForTests,
   tryProxyCodexWebSocket,
 } from "../../src/providers/proxies/codex-websocket";
 import { prepareCopilotProxyRequest } from "../../src/providers/proxies/copilot-proxy";
 import { createOpenAiSseUsagePassthrough } from "../../src/providers/proxies/openai-sse-passthrough";
 import type { TokenUsage } from "../../src/usage/token-usage";
 
-const originalWebSocket = globalThis.WebSocket;
-
 afterEach(() => {
   closeCodexWebSocketSessions();
-  globalThis.WebSocket = originalWebSocket;
+  setCodexWebSocketConstructorForTests(null);
 });
 
 const createUsageCapture = () => {
@@ -168,7 +167,7 @@ const installCodexWebSocketMock = (
     }
   }
 
-  globalThis.WebSocket = MockWebSocket as unknown as typeof WebSocket;
+  setCodexWebSocketConstructorForTests(MockWebSocket);
 };
 
 type ManualCodexWebSocket = {
@@ -224,7 +223,7 @@ const installManualCodexWebSocketMock = (
     }
   }
 
-  globalThis.WebSocket = MockWebSocket as unknown as typeof WebSocket;
+  setCodexWebSocketConstructorForTests(MockWebSocket);
   return sockets;
 };
 

--- a/tests/providers/proxy-contract.test.ts
+++ b/tests/providers/proxy-contract.test.ts
@@ -22,6 +22,7 @@ import {
   tryProxyCodexWebSocket,
 } from "../../src/providers/proxies/codex-websocket";
 import { prepareCopilotProxyRequest } from "../../src/providers/proxies/copilot-proxy";
+import { createOpenAiSseUsagePassthrough } from "../../src/providers/proxies/openai-sse-passthrough";
 import type { TokenUsage } from "../../src/usage/token-usage";
 
 const originalWebSocket = globalThis.WebSocket;
@@ -583,6 +584,36 @@ describe("proxy contract: codex", () => {
       cacheReadTokens: 9,
       cacheWriteTokens: 0,
     });
+  });
+
+  test("applies downstream backpressure to OpenAI SSE reads", async () => {
+    const encoder = new TextEncoder();
+    let pulls = 0;
+    const source = new Response(
+      new ReadableStream<Uint8Array>(
+        {
+          pull(controller): void {
+            pulls++;
+            controller.enqueue(
+              encoder.encode(
+                `data: ${JSON.stringify({ type: "response.output_text.delta", delta: pulls })}\n\n`
+              )
+            );
+          },
+        },
+        { highWaterMark: 0 }
+      ),
+      { headers: { "content-type": "text/event-stream" } }
+    );
+
+    const transformed = createOpenAiSseUsagePassthrough({
+      response: source,
+      extractUsage: () => null,
+    });
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    expect(pulls).toBe(1);
+    await transformed.body?.cancel();
   });
 
   test("uses websocket cached delta transport for streaming requests", async () => {
@@ -2293,6 +2324,34 @@ describe("proxy contract: claude", () => {
     expect(transformedResponse.headers.get("content-length")).toBeNull();
     const transformedText = await transformedResponse.text();
     expect(transformedText).toContain('"name":"shell"');
+  });
+
+  test("applies downstream backpressure to Claude SSE reads", async () => {
+    const result = prepareClaudeUsageRequest();
+    const encoder = new TextEncoder();
+    let pulls = 0;
+    const source = new Response(
+      new ReadableStream<Uint8Array>(
+        {
+          pull(controller): void {
+            pulls++;
+            controller.enqueue(
+              encoder.encode(
+                `data: ${JSON.stringify({ type: "content_block_delta", index: pulls })}\n\n`
+              )
+            );
+          },
+        },
+        { highWaterMark: 0 }
+      ),
+      { headers: { "content-type": "text/event-stream" } }
+    );
+
+    const transformed = await result.transformResponse(source);
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    expect(pulls).toBe(1);
+    await transformed.body?.cancel();
   });
 
   test("logs claude streaming error event details", async () => {

--- a/tests/providers/proxy-contract.test.ts
+++ b/tests/providers/proxy-contract.test.ts
@@ -705,26 +705,36 @@ describe("proxy contract: codex", () => {
     const sentBodies: unknown[] = [];
     const sockets = installManualCodexWebSocketMock(sentBodies);
     const abortController = new AbortController();
-    const responsePromise = tryProxyCodexWebSocket({
-      headers: new Headers({
-        authorization: "Bearer codex-access",
-        [CODEX_ACCOUNT_ID_HEADER]: "acct_1",
-        "x-session-affinity": "abort-session",
-      }),
-      bodyJson: {
-        model: "gpt-5.5",
-        stream: true,
-        input: [{ role: "user", content: "hello" }],
-      },
-      accountKey: "key-1:account-1",
-      signal: abortController.signal,
-    });
-    await waitFor(() => sentBodies.length === 1);
+    const warnings: string[] = [];
+    const originalWarn = console.warn;
+    console.warn = (message?: unknown): void => {
+      warnings.push(String(message));
+    };
 
-    abortController.abort(new Error("stop"));
+    try {
+      const responsePromise = tryProxyCodexWebSocket({
+        headers: new Headers({
+          authorization: "Bearer codex-access",
+          [CODEX_ACCOUNT_ID_HEADER]: "acct_1",
+          "x-session-affinity": "abort-session",
+        }),
+        bodyJson: {
+          model: "gpt-5.5",
+          stream: true,
+          input: [{ role: "user", content: "hello" }],
+        },
+        accountKey: "key-1:account-1",
+        signal: abortController.signal,
+      });
+      await waitFor(() => sentBodies.length === 1);
+      abortController.abort(new Error("stop"));
+      expect(await responsePromise).toBeNull();
+    } finally {
+      console.warn = originalWarn;
+    }
 
-    expect(await responsePromise).toBeNull();
     expect(sockets[0]?.terminated).toBe(true);
+    expect(warnings).toHaveLength(0);
   });
 
   test("uses websocket cached delta transport for streaming requests", async () => {
@@ -1749,12 +1759,32 @@ describe("proxy contract: codex", () => {
     });
     const failedResponse = await failedResponsePromise;
     const failedText = failedResponse?.text();
-    sockets[0]?.dispatch("close", { code: 1006, reason: "Connection ended" });
-    const streamFailed = await failedText?.then(
-      () => false,
-      () => true
-    );
+    const warnings: string[] = [];
+    const originalWarn = console.warn;
+    console.warn = (message?: unknown): void => {
+      warnings.push(String(message));
+    };
+    let streamFailed: boolean | undefined;
+    try {
+      sockets[0]?.dispatch("close", {
+        code: 1006,
+        reason: "Connection ended",
+      });
+      streamFailed = await failedText?.then(
+        () => false,
+        () => true
+      );
+    } finally {
+      console.warn = originalWarn;
+    }
     expect(streamFailed).toBe(true);
+    expect(warnings).toHaveLength(1);
+    const warning = JSON.parse(warnings[0] ?? "{}") as Record<string, unknown>;
+    expect(warning.event).toBe("codex_websocket_stream_failed");
+    expect(warning.payloadCount).toBe(1);
+    expect(typeof warning.requestBytes).toBe("number");
+    expect(typeof warning.upstreamIdleMs).toBe("number");
+    expect(typeof warning.downstreamIdleMs).toBe("number");
 
     const sameSession = await tryProxyCodexWebSocket({
       headers,

--- a/tests/providers/proxy-contract.test.ts
+++ b/tests/providers/proxy-contract.test.ts
@@ -80,10 +80,16 @@ type MockCodexWebSocketResponse = {
   terminalType?: "response.completed" | "response.done" | "response.incomplete";
 };
 
+type MockWebSocketOptions = {
+  headers?: Record<string, string>;
+  agent?: unknown;
+};
+
 const installCodexWebSocketMock = (
   responses: MockCodexWebSocketResponse[],
   sentBodies: unknown[],
-  constructorHeaders: Record<string, string>[] = []
+  constructorHeaders: Record<string, string>[] = [],
+  constructorOptions: MockWebSocketOptions[] = []
 ): void => {
   class MockWebSocket {
     static OPEN = 1;
@@ -93,17 +99,12 @@ const installCodexWebSocketMock = (
       Set<(event: unknown) => void>
     >();
 
-    constructor(
-      _url: string,
-      protocols?: string | string[] | { headers?: Record<string, string> }
-    ) {
-      if (
-        protocols &&
-        typeof protocols === "object" &&
-        !Array.isArray(protocols) &&
-        protocols.headers
-      ) {
-        constructorHeaders.push(protocols.headers);
+    constructor(_url: string, options?: MockWebSocketOptions) {
+      if (options) {
+        constructorOptions.push(options);
+      }
+      if (options?.headers) {
+        constructorHeaders.push(options.headers);
       }
       queueMicrotask(() => this.dispatch("open", {}));
     }
@@ -121,7 +122,7 @@ const installCodexWebSocketMock = (
       this.listeners.get(type)?.delete(listener);
     }
 
-    send(data: string): void {
+    send(data: string, callback?: (error?: Error) => void): void {
       sentBodies.push(JSON.parse(data) as unknown);
       const response = responses.shift();
       if (!response) {
@@ -129,6 +130,7 @@ const installCodexWebSocketMock = (
       }
 
       queueMicrotask(() => {
+        callback?.();
         for (const event of [
           { type: "response.created", response: { id: response.id } },
           ...(response.items ?? []).map((item) => ({
@@ -160,6 +162,10 @@ const installCodexWebSocketMock = (
       this.readyState = 3;
     }
 
+    terminate(): void {
+      this.readyState = 3;
+    }
+
     private dispatch(type: string, event: unknown): void {
       for (const listener of this.listeners.get(type) ?? []) {
         listener(event);
@@ -172,6 +178,7 @@ const installCodexWebSocketMock = (
 
 type ManualCodexWebSocket = {
   dispatch(type: string, event: unknown): void;
+  readonly terminated: boolean;
 };
 
 const installManualCodexWebSocketMock = (
@@ -183,6 +190,7 @@ const installManualCodexWebSocketMock = (
   class MockWebSocket {
     static OPEN = 1;
     readyState = MockWebSocket.OPEN;
+    terminated = false;
     private readonly listeners = new Map<
       string,
       Set<(event: unknown) => void>
@@ -208,11 +216,17 @@ const installManualCodexWebSocketMock = (
       this.listeners.get(type)?.delete(listener);
     }
 
-    send(data: string): void {
+    send(data: string, callback?: (error?: Error) => void): void {
       sentBodies.push(JSON.parse(data) as unknown);
+      callback?.();
     }
 
     close(): void {
+      this.readyState = 3;
+    }
+
+    terminate(): void {
+      this.terminated = true;
       this.readyState = 3;
     }
 
@@ -642,6 +656,75 @@ describe("proxy contract: codex", () => {
     expect(response).toBeNull();
     expect(sockets).toHaveLength(0);
     expect(sentBodies).toHaveLength(0);
+  });
+
+  test("uses standard proxy environment for websocket connections", async () => {
+    const sentBodies: unknown[] = [];
+    const constructorOptions: MockWebSocketOptions[] = [];
+    installCodexWebSocketMock(
+      [{ id: "resp_proxy" }],
+      sentBodies,
+      [],
+      constructorOptions
+    );
+    const originalHttpsProxy = process.env.HTTPS_PROXY;
+    const originalHttpsProxyLower = process.env.https_proxy;
+    const originalNoProxy = process.env.NO_PROXY;
+    const originalNoProxyLower = process.env.no_proxy;
+    process.env.HTTPS_PROXY = "http://127.0.0.1:3128";
+    process.env.https_proxy = "http://127.0.0.1:3128";
+    process.env.NO_PROXY = "";
+    process.env.no_proxy = "";
+
+    try {
+      const response = await tryProxyCodexWebSocket({
+        headers: new Headers({
+          authorization: "Bearer codex-access",
+          [CODEX_ACCOUNT_ID_HEADER]: "acct_1",
+          "x-session-affinity": "proxy-session",
+        }),
+        bodyJson: {
+          model: "gpt-5.5",
+          stream: true,
+          input: [{ role: "user", content: "hello" }],
+        },
+        accountKey: "key-1:account-1",
+      });
+      await response?.text();
+    } finally {
+      process.env.HTTPS_PROXY = originalHttpsProxy;
+      process.env.https_proxy = originalHttpsProxyLower;
+      process.env.NO_PROXY = originalNoProxy;
+      process.env.no_proxy = originalNoProxyLower;
+    }
+
+    expect(constructorOptions[0]?.agent).toBeDefined();
+  });
+
+  test("terminates websocket when the downstream request aborts", async () => {
+    const sentBodies: unknown[] = [];
+    const sockets = installManualCodexWebSocketMock(sentBodies);
+    const abortController = new AbortController();
+    const responsePromise = tryProxyCodexWebSocket({
+      headers: new Headers({
+        authorization: "Bearer codex-access",
+        [CODEX_ACCOUNT_ID_HEADER]: "acct_1",
+        "x-session-affinity": "abort-session",
+      }),
+      bodyJson: {
+        model: "gpt-5.5",
+        stream: true,
+        input: [{ role: "user", content: "hello" }],
+      },
+      accountKey: "key-1:account-1",
+      signal: abortController.signal,
+    });
+    await waitFor(() => sentBodies.length === 1);
+
+    abortController.abort(new Error("stop"));
+
+    expect(await responsePromise).toBeNull();
+    expect(sockets[0]?.terminated).toBe(true);
   });
 
   test("uses websocket cached delta transport for streaming requests", async () => {

--- a/tests/providers/proxy-contract.test.ts
+++ b/tests/providers/proxy-contract.test.ts
@@ -645,31 +645,6 @@ describe("proxy contract: codex", () => {
     expect(sentBodies).toHaveLength(0);
   });
 
-  test("routes oversized response.create frames over HTTP", async () => {
-    const sentBodies: unknown[] = [];
-    const sockets = installManualCodexWebSocketMock(sentBodies);
-    const headers = new Headers({
-      authorization: "Bearer codex-access",
-      [CODEX_ACCOUNT_ID_HEADER]: "acct_1",
-      "x-session-affinity": "oversized-session",
-    });
-
-    const response = await tryProxyCodexWebSocket({
-      headers,
-      bodyJson: {
-        model: "gpt-5.5",
-        stream: true,
-        input: [{ role: "user", content: "x".repeat(256) }],
-      },
-      accountKey: "key-1:account-1",
-      maxRequestBytes: 128,
-    });
-
-    expect(response).toBeNull();
-    expect(sockets).toHaveLength(1);
-    expect(sentBodies).toHaveLength(0);
-  });
-
   test("uses websocket cached delta transport for streaming requests", async () => {
     const firstAssistantItem = {
       type: "message",

--- a/tests/providers/proxy-contract.test.ts
+++ b/tests/providers/proxy-contract.test.ts
@@ -629,6 +629,31 @@ describe("proxy contract: codex", () => {
     await transformed.body?.cancel();
   });
 
+  test("preserves explicit JSON content type for streaming errors", async () => {
+    const body = JSON.stringify({
+      error: { message: "bad request", type: "invalid_request_error" },
+    });
+    const response = createOpenAiSseUsagePassthrough({
+      response: new Response(body, {
+        status: 400,
+        headers: {
+          "content-encoding": "gzip",
+          "content-length": String(body.length),
+          "content-type": "application/json",
+        },
+      }),
+      extractUsage: () => null,
+    });
+
+    expect(response.status).toBe(400);
+    expect(response.headers.get("content-type")).toBe("application/json");
+    expect(response.headers.has("content-length")).toBe(false);
+    expect(response.headers.has("content-encoding")).toBe(false);
+    expect(await response.json()).toEqual({
+      error: { message: "bad request", type: "invalid_request_error" },
+    });
+  });
+
   test("routes compaction turns over HTTP instead of WebSocket", async () => {
     const sentBodies: unknown[] = [];
     const sockets = installManualCodexWebSocketMock(sentBodies);
@@ -671,6 +696,16 @@ describe("proxy contract: codex", () => {
     const originalHttpsProxyLower = process.env.https_proxy;
     const originalNoProxy = process.env.NO_PROXY;
     const originalNoProxyLower = process.env.no_proxy;
+    const restoreEnvironment = (
+      key: string,
+      value: string | undefined
+    ): void => {
+      if (value === undefined) {
+        Reflect.deleteProperty(process.env, key);
+        return;
+      }
+      process.env[key] = value;
+    };
     process.env.HTTPS_PROXY = "http://127.0.0.1:3128";
     process.env.https_proxy = "http://127.0.0.1:3128";
     process.env.NO_PROXY = "";
@@ -692,10 +727,10 @@ describe("proxy contract: codex", () => {
       });
       await response?.text();
     } finally {
-      process.env.HTTPS_PROXY = originalHttpsProxy;
-      process.env.https_proxy = originalHttpsProxyLower;
-      process.env.NO_PROXY = originalNoProxy;
-      process.env.no_proxy = originalNoProxyLower;
+      restoreEnvironment("HTTPS_PROXY", originalHttpsProxy);
+      restoreEnvironment("https_proxy", originalHttpsProxyLower);
+      restoreEnvironment("NO_PROXY", originalNoProxy);
+      restoreEnvironment("no_proxy", originalNoProxyLower);
     }
 
     expect(constructorOptions[0]?.agent).toBeDefined();

--- a/tests/providers/proxy-contract.test.ts
+++ b/tests/providers/proxy-contract.test.ts
@@ -1721,6 +1721,68 @@ describe("proxy contract: codex", () => {
     expect(sockets).toHaveLength(6);
   });
 
+  test("isolates close-before-terminal fallback to one session", async () => {
+    const sentBodies: unknown[] = [];
+    const sockets = installManualCodexWebSocketMock(sentBodies);
+    const headers = new Headers({
+      authorization: "Bearer codex-access",
+      [CODEX_ACCOUNT_ID_HEADER]: "acct_1",
+      "x-session-affinity": "failed-session",
+    });
+    const bodyJson = {
+      model: "gpt-5.5",
+      stream: true,
+      input: [{ role: "user", content: "hello" }],
+    };
+
+    const failedResponsePromise = tryProxyCodexWebSocket({
+      headers,
+      bodyJson,
+      accountKey: "key-1:account-1",
+    });
+    await waitFor(() => sentBodies.length === 1);
+    sockets[0]?.dispatch("message", {
+      data: JSON.stringify({
+        type: "response.created",
+        response: { id: "resp_failed" },
+      }),
+    });
+    const failedResponse = await failedResponsePromise;
+    const failedText = failedResponse?.text();
+    sockets[0]?.dispatch("close", { code: 1006, reason: "Connection ended" });
+    const streamFailed = await failedText?.then(
+      () => false,
+      () => true
+    );
+    expect(streamFailed).toBe(true);
+
+    const sameSession = await tryProxyCodexWebSocket({
+      headers,
+      bodyJson,
+      accountKey: "key-1:account-1",
+    });
+    expect(sameSession).toBeNull();
+    expect(sockets).toHaveLength(1);
+
+    headers.set("x-session-affinity", "healthy-session");
+    const healthyResponsePromise = tryProxyCodexWebSocket({
+      headers,
+      bodyJson,
+      accountKey: "key-1:account-1",
+    });
+    await waitFor(() => sentBodies.length === 2);
+    sockets[1]?.dispatch("message", {
+      data: JSON.stringify({
+        type: "response.completed",
+        response: { id: "resp_healthy", status: "completed" },
+      }),
+    });
+    const healthyResponse = await healthyResponsePromise;
+
+    expect(await healthyResponse?.text()).toContain("response.completed");
+    expect(sockets).toHaveLength(2);
+  });
+
   test("treats same-session websocket connect races as busy", async () => {
     const sentBodies: unknown[] = [];
     const sockets = installManualCodexWebSocketMock(sentBodies, {


### PR DESCRIPTION
## Summary

Hardens long-stream reliability across the proxy transports, aligning the Codex WebSocket transport with OpenCode's implementation (`ws` client, hard termination, session-scoped fallback).

### Downstream SSE delivery
- Codex WebSocket streams now emit SSE keepalive comments so idle proxies/load balancers don't kill long turns
- Strips stale `content-length`/`content-encoding`, adds `Cache-Control: no-cache, no-transform` and `X-Accel-Buffering: no`
- Explicit upstream content types (e.g. JSON error bodies on streaming requests) are preserved instead of being relabeled as `text/event-stream`, and keepalive comments are never injected into non-SSE bodies

### Upstream lifecycle
- Every upstream fetch receives the downstream request's abort signal, so client disconnects cancel upstream work (and are not recorded as 500 proxy failures)
- Claude/OpenAI SSE transforms are pull-driven, preserving downstream backpressure instead of buffering unboundedly

### Codex WebSocket transport (aligned with OpenCode)
- Migrated from Bun's native WebSocket to `ws@8.21.0` (same client OpenCode uses): `terminate()` for hard cleanup of invalid/aborted/timed-out sockets, send-completion callbacks, graceful close only for healthy reuse
- Connection-limit retries are race-safe: events from a replaced socket are ignored via a socket epoch, and a retry that loses to a concurrent failure terminates its socket instead of leaking it
- Compaction turns (`X-Codex-Turn-Metadata: request_kind=compaction`) deterministically route over HTTP, avoiding `1009 message too big` closes
- Fallback to SSE remains strictly session-scoped with a 5 minute TTL: a mid-stream `1006` moves only that session to HTTP; other sessions keep using WebSocket
- Failure tracking maps are bounded (1000 sessions, FIFO eviction)

### Diagnostics
- Expected client cancellations no longer log warnings
- Real stream failures include `requestBytes`, `payloadCount`, `upstreamIdleMs`, `downstreamIdleMs`, and WebSocket close codes

## Test plan
- [x] `bun test` (83 tests, includes new coverage for abort termination, retry/close races, session fallback isolation, backpressure, content-type preservation, keepalive suppression)
- [x] `bun typecheck`
- [x] `bun lint`
- [x] `bun run build`
- [x] Two independent agent review passes of the full diff (all findings fixed)