### PR TITLE
fix(codex): avoid duplicate client instructions

### DIFF
--- a/src/providers/proxies/codex-proxy.ts
+++ b/src/providers/proxies/codex-proxy.ts
@@ -22,6 +22,34 @@ import {
 const trimString = (value: unknown): string =>
   typeof value === "string" ? value.trim() : "";
 
+const readLeadingInputInstruction = (body: JsonObject): string | null => {
+  if (!Array.isArray(body.input)) {
+    return null;
+  }
+  const first = body.input[0];
+  if (!isObjectRecord(first)) {
+    return null;
+  }
+  const role = trimString(first.role);
+  if (role !== "system" && role !== "developer") {
+    return null;
+  }
+  if (typeof first.content === "string") {
+    return trimString(first.content) || null;
+  }
+  if (!Array.isArray(first.content)) {
+    return null;
+  }
+  const textParts: string[] = [];
+  for (const part of first.content) {
+    if (!isObjectRecord(part) || typeof part.text !== "string") {
+      return null;
+    }
+    textParts.push(part.text);
+  }
+  return trimString(textParts.join("\n")) || null;
+};
+
 const toHex = (bytes: Uint8Array): string =>
   Array.from(bytes, (byte) => byte.toString(16).padStart(2, "0")).join("");
 
@@ -88,15 +116,20 @@ export const transformCodexBodyJson = (
     ...nextBody
   } = bodyJson;
 
-  // OpenCode injects instructions internally in its Codex/OAuth path:
-  // https://github.com/anomalyco/opencode/blob/d848c9b6a32f408e8b9bf6448b83af05629454d0/packages/opencode/src/session/llm.ts#L110-L112
-  // Non-Codex clients won't, so we fall back to OpenCode's default instructions for Codex.
-  // https://github.com/anomalyco/opencode/blob/d848c9b6a32f408e8b9bf6448b83af05629454d0/packages/opencode/src/session/prompt/codex_header.txt
+  const incomingInstructions = trimString(nextBody.instructions);
+  const leadingInputInstruction = incomingInstructions
+    ? null
+    : readLeadingInputInstruction(nextBody);
   const instructions =
-    trimString(nextBody.instructions) || CODEX_DEFAULT_INSTRUCTIONS;
+    incomingInstructions ||
+    leadingInputInstruction ||
+    CODEX_DEFAULT_INSTRUCTIONS;
 
   return {
     ...nextBody,
+    ...(leadingInputInstruction && Array.isArray(nextBody.input)
+      ? { input: nextBody.input.slice(1) }
+      : {}),
     instructions,
     store: false,
     ...(sessionId ? { prompt_cache_key: sessionId } : {}),

--- a/src/providers/proxies/codex-proxy.ts
+++ b/src/providers/proxies/codex-proxy.ts
@@ -22,34 +22,6 @@ import {
 const trimString = (value: unknown): string =>
   typeof value === "string" ? value.trim() : "";
 
-const readLeadingInputInstruction = (body: JsonObject): string | null => {
-  if (!Array.isArray(body.input)) {
-    return null;
-  }
-  const first = body.input[0];
-  if (!isObjectRecord(first)) {
-    return null;
-  }
-  const role = trimString(first.role);
-  if (role !== "system" && role !== "developer") {
-    return null;
-  }
-  if (typeof first.content === "string") {
-    return trimString(first.content) || null;
-  }
-  if (!Array.isArray(first.content)) {
-    return null;
-  }
-  const textParts: string[] = [];
-  for (const part of first.content) {
-    if (!isObjectRecord(part) || typeof part.text !== "string") {
-      return null;
-    }
-    textParts.push(part.text);
-  }
-  return trimString(textParts.join("\n")) || null;
-};
-
 const toHex = (bytes: Uint8Array): string =>
   Array.from(bytes, (byte) => byte.toString(16).padStart(2, "0")).join("");
 
@@ -117,19 +89,20 @@ export const transformCodexBodyJson = (
   } = bodyJson;
 
   const incomingInstructions = trimString(nextBody.instructions);
-  const leadingInputInstruction = incomingInstructions
-    ? null
-    : readLeadingInputInstruction(nextBody);
+  const input = Array.isArray(nextBody.input) ? nextBody.input : [];
+  const firstInput = input[0];
+  const promotedInstructions =
+    !incomingInstructions &&
+    isObjectRecord(firstInput) &&
+    (firstInput.role === "system" || firstInput.role === "developer")
+      ? trimString(firstInput.content)
+      : "";
   const instructions =
-    incomingInstructions ||
-    leadingInputInstruction ||
-    CODEX_DEFAULT_INSTRUCTIONS;
+    incomingInstructions || promotedInstructions || CODEX_DEFAULT_INSTRUCTIONS;
 
   return {
     ...nextBody,
-    ...(leadingInputInstruction && Array.isArray(nextBody.input)
-      ? { input: nextBody.input.slice(1) }
-      : {}),
+    ...(promotedInstructions ? { input: input.slice(1) } : {}),
     instructions,
     store: false,
     ...(sessionId ? { prompt_cache_key: sessionId } : {}),

--- a/tests/providers/proxy-contract.test.ts
+++ b/tests/providers/proxy-contract.test.ts
@@ -338,6 +338,39 @@ describe("proxy contract: codex", () => {
     );
   });
 
+  test("promotes OpenCode developer input instead of adding fallback instructions", () => {
+    const headers = new Headers();
+    const bodyJson = {
+      model: "gpt-5.6-sol",
+      input: [
+        {
+          role: "developer",
+          content: "Current OpenCode GPT instructions",
+        },
+        {
+          role: "user",
+          content: [{ type: "input_text", text: "hello" }],
+        },
+      ],
+    };
+
+    const result = prepareCodexProxyRequest({
+      headers,
+      accessToken: "codex-access",
+      accountId: "acct-fallback",
+      metadata: null,
+      bodyText: JSON.stringify(bodyJson),
+      bodyJson,
+    });
+
+    expect(JSON.parse(result.bodyText)).toEqual({
+      model: "gpt-5.6-sol",
+      input: [bodyJson.input[1]],
+      instructions: "Current OpenCode GPT instructions",
+      store: false,
+    });
+  });
+
   test("uses derived session headers and prompt cache key for codex requests", () => {
     const headers = new Headers({
       session_id: "raw-session-underscore",


### PR DESCRIPTION
## Summary
- promote a leading system/developer input into top-level Codex instructions when the client omits that field
- remove the promoted input item to match OpenCode native OAuth request shape
- retain explicit client instructions and use the vendored fallback only when no instruction context exists

## Context
OpenCode sends its current GPT prompt as a developer input when using Kleis. Kleis previously also injected its vendored Codex fallback, causing gpt-5.5 and gpt-5.6-sol to receive two overlapping system prompts.

## Verification
- `bun test` (86 pass)
- `bun lint`
- `bun typecheck`
- `git diff --check`